### PR TITLE
Remove default props, add more exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ return (
 )
 ```
 
+## Development
+
+`npm i && npm start`
+
+## Contributing
+
+Yes, thank you!
+
 ## License
 
 MIT

--- a/src/components/Alert.jsx
+++ b/src/components/Alert.jsx
@@ -1,4 +1,3 @@
-import PropTypes from 'prop-types'
 import { Box, Text } from 'grommet'
 import { normalizeColor } from 'grommet/utils'
 import styled from 'styled-components'
@@ -43,7 +42,7 @@ const CloseContainer = styled(Box)`
   cursor: pointer;
 `
 
-function Alert({ severity, children, title, onClose }) {
+function Alert({ children, severity = 'info', title = '', onClose = () => {} }) {
   const Icon = severityToIcon[severity] || StatusOkIcon
   const color = severityToColor[severity] || 'brand'
 
@@ -80,18 +79,6 @@ function Alert({ severity, children, title, onClose }) {
       </Box>
     </Container>
   )
-}
-
-Alert.propTypes = {
-  severity: PropTypes.oneOf(['success', 'warning', 'error', 'info']),
-  title: PropTypes.string,
-  onClose: PropTypes.func,
-}
-
-Alert.defaultProps = {
-  severity: 'info',
-  title: '',
-  onClose: null,
 }
 
 export default Alert

--- a/src/components/Avatar.jsx
+++ b/src/components/Avatar.jsx
@@ -1,4 +1,3 @@
-import PropTypes from 'prop-types'
 import { Box, Text } from 'grommet'
 import styled from 'styled-components'
 
@@ -24,7 +23,7 @@ function extractInitials(name) {
   return words.map(word => word[0]).filter((_, i, a) => i === 0 || i === a.length - 1).join('').toUpperCase()
 }
 
-function Avatar({ name, imageUrl, ...props }) {
+function Avatar({ name = '', imageUrl = '', ...props }) {
   function renderName() {
     return (
       <Text weight="bold">
@@ -53,16 +52,6 @@ function Avatar({ name, imageUrl, ...props }) {
       {imageUrl ? renderImage() : renderName()}
     </Wrapper>
   )
-}
-
-Avatar.propTypes = {
-  name: PropTypes.string,
-  imageUrl: PropTypes.string,
-}
-
-Avatar.defaultProps = {
-  name: '',
-  imageUrl: '',
 }
 
 export default Avatar

--- a/src/components/FormField.jsx
+++ b/src/components/FormField.jsx
@@ -1,7 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { FormField as GrommetFormField, Text } from 'grommet'
 import styled from 'styled-components'
-import PropTypes from 'prop-types'
 
 const Wrapper = styled.div`
   position: relative;
@@ -13,7 +12,7 @@ const Caption = styled(Text)`
   right: 0;
 `
 
-export default function FormField({ label, caption, style, className, valid, error, ...props }) {
+export default function FormField({ style, className, label = '', caption = '', valid = false, error = false, ...props }) {
   const labelRef = useRef()
   const [captionMaxWidth, setCaptionMaxWidth] = useState('auto')
 
@@ -46,18 +45,4 @@ export default function FormField({ label, caption, style, className, valid, err
       />
     </Wrapper>
   )
-}
-
-FormField.propTypes = {
-  label: PropTypes.string,
-  caption: PropTypes.string,
-  valid: PropTypes.bool,
-  error: PropTypes.bool,
-}
-
-FormField.defaultProps = {
-  label: '',
-  caption: '',
-  valid: false,
-  error: false,
 }

--- a/src/components/Menu.jsx
+++ b/src/components/Menu.jsx
@@ -17,7 +17,4 @@ function Menu(props) {
   )
 }
 
-Menu.propTypes = Box.propTypes
-Menu.defaultProps = Box.defaultProps
-
 export default Menu

--- a/src/components/MenuItem.jsx
+++ b/src/components/MenuItem.jsx
@@ -20,7 +20,4 @@ function MenuItem(props) {
   )
 }
 
-MenuItem.propTypes = Box.propTypes
-MenuItem.defaultProps = Box.defaultProps
-
 export default MenuItem

--- a/src/components/RepositoryCard.jsx
+++ b/src/components/RepositoryCard.jsx
@@ -1,6 +1,5 @@
 import { Box, Text } from 'grommet'
 import { normalizeColor } from 'grommet/utils'
-import PropTypes from 'prop-types'
 import styled from 'styled-components'
 
 import CheckOutlineIcon from './icons/CheckOutlineIcon'
@@ -28,12 +27,11 @@ const LogoLarge = styled.img`
 `
 
 export default function RepositoryCard({
-  featured,
-  installed,
-  title,
-  subtitle,
-  imageUrl,
-  onClick,
+  featured = false,
+  installed = false,
+  title = '',
+  subtitle = '',
+  imageUrl = '',
   children,
   ...props
 }) {
@@ -128,23 +126,4 @@ export default function RepositoryCard({
   }
 
   return featured ? renderFeatured() : renderRegular()
-}
-
-RepositoryCard.propTypes = {
-  ...Box.propTypes,
-  featured: PropTypes.bool,
-  installed: PropTypes.bool,
-  title: PropTypes.string.isRequired,
-  subtitle: PropTypes.string.isRequired,
-  imageUrl: PropTypes.string.isRequired,
-  onClick: PropTypes.func,
-}
-
-RepositoryCard.defaultProps = {
-  featured: false,
-  installed: false,
-  title: '',
-  subtitle: '',
-  imageUrl: '',
-  onClick: () => null,
 }

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -76,7 +76,12 @@ const ChildrenContainer = styled(Box)`
   }
 `
 
-function Sidebar({ items, activeUrl, user, onItemClick = () => null }) {
+function Sidebar({
+  items = [],
+  activeUrl = '',
+  user = {},
+  onItemClick = () => null,
+}) {
   const sidebarBottomRef = useRef()
   const [collapsed, setCollapsed] = useState(false)
   const [deployedIds, setDeployedIds] = useState(activeUrl ? [activeUrl] : [])

--- a/src/components/Switch.jsx
+++ b/src/components/Switch.jsx
@@ -26,7 +26,7 @@ const Handle = styled.div`
   transition: all 150ms ease;
 `
 
-function Switch({ checked, onChange, ...props }) {
+function Switch({ checked = false, onChange = () => {}, ...props }) {
   return (
     <Wrapper {...props}>
       <Inner

--- a/src/components/Tag.jsx
+++ b/src/components/Tag.jsx
@@ -23,7 +23,4 @@ function Tag({ children, ...props }) {
   )
 }
 
-Tag.propTypes = Box.propTypes
-Tag.defaultProps = Box.defaultProps
-
 export default Tag

--- a/src/components/TextInput.jsx
+++ b/src/components/TextInput.jsx
@@ -1,6 +1,5 @@
 import { TextInput as GrommetTextInput } from 'grommet'
 import { normalizeColor } from 'grommet/utils'
-import PropTypes from 'prop-types'
 import styled from 'styled-components'
 
 const ValidTextInput = styled(GrommetTextInput)`
@@ -17,19 +16,9 @@ const ErrorTextInput = styled(GrommetTextInput)`
   }
 `
 
-export default function TextInput({ valid, error, ...props }) {
+export default function TextInput({ valid = false, error = false, ...props }) {
   if (valid) return <ValidTextInput {...props} />
   if (error) return <ErrorTextInput {...props} />
 
   return <GrommetTextInput {...props} />
-}
-
-TextInput.propTypes = {
-  valid: PropTypes.bool,
-  error: PropTypes.bool,
-}
-
-TextInput.defaultProps = {
-  valid: false,
-  error: false,
 }

--- a/src/components/Token.jsx
+++ b/src/components/Token.jsx
@@ -1,5 +1,4 @@
 import { Box, Text } from 'grommet'
-import PropTypes from 'prop-types'
 import styled from 'styled-components'
 
 import CloseIcon from './icons/CloseIcon'
@@ -16,7 +15,7 @@ const IconContainer = styled.span`
   cursor: pointer;
 `
 
-export default function Token({ children, onClose, ...props }) {
+export default function Token({ children, onClose = () => {}, ...props }) {
 
   return (
     <Container
@@ -37,13 +36,4 @@ export default function Token({ children, onClose, ...props }) {
       </IconContainer>
     </Container>
   )
-}
-
-Token.propTypes = {
-  children: PropTypes.node.isRequired,
-  onClose: PropTypes.func,
-}
-
-Token.defaultProps = {
-  onClose: () => null,
 }

--- a/src/components/UserCard.jsx
+++ b/src/components/UserCard.jsx
@@ -1,9 +1,8 @@
 import { Box, Text } from 'grommet'
-import PropTypes from 'prop-types'
 
 import Avatar from './Avatar'
 
-export default function UserCard({ user, ...props }) {
+export default function UserCard({ user = {}, ...props }) {
 
   return (
     <Box
@@ -34,15 +33,4 @@ export default function UserCard({ user, ...props }) {
       </Box>
     </Box>
   )
-}
-
-UserCard.propTypes = {
-  user: PropTypes.shape({
-    name: PropTypes.string.isRequired,
-    imageUrl: PropTypes.string,
-    email: PropTypes.string,
-  }).isRequired,
-}
-
-UserCard.defaultProps = {
 }

--- a/src/components/icons/createIcon.js
+++ b/src/components/icons/createIcon.js
@@ -1,24 +1,13 @@
 import { useContext } from 'react'
-import PropTypes from 'prop-types'
 import { ThemeContext } from 'grommet'
 import { normalizeColor } from 'grommet/utils'
 
 function createIcon(render) {
-  function Icon({ size, color, ...props }) {
+  function Icon({ size = 16, color = 'white', ...props }) {
     const theme = useContext(ThemeContext)
     const workingColor = normalizeColor(color, theme)
 
     return render({ size, color: workingColor, ...props })
-  }
-
-  Icon.propTypes = {
-    size: PropTypes.number,
-    color: PropTypes.string,
-  }
-
-  Icon.defaultProps = {
-    size: 16,
-    color: 'white',
   }
 
   return Icon

--- a/src/index.js
+++ b/src/index.js
@@ -104,6 +104,7 @@ export { default as Switch } from './components/Switch'
 export { default as Tag } from './components/Tag'
 export { default as TextInput } from './components/TextInput'
 export { default as Token } from './components/Token'
+export { default as UserCard } from './components/UserCard'
 // Hooks
 export { default as usePrevious } from './hooks/usePrevious'
 // Theme

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,5 +1,0 @@
-// jest-dom adds custom jest matchers for asserting on DOM nodes.
-// allows you to do things like:
-// expect(element).toHaveTextContent(/react/i)
-// learn more: https://github.com/testing-library/jest-dom
-import '@testing-library/jest-dom'


### PR DESCRIPTION
propTypes and defaultProps are about to get deprecated. Most IntelliSense implementations for JSX won't rely on them, but on function args in the future.

Also adds a missing export and edit README