### PR TITLE
Add matchedUrl param on SidebarItem

### DIFF
--- a/src/components/Sidebar.stories.tsx
+++ b/src/components/Sidebar.stories.tsx
@@ -27,6 +27,7 @@ function Template(args: any) {
       name: 'Explore',
       Icon: ScrollIcon,
       url: '/',
+      matchedUrl: /\/explore\S*/i,
     }),
     createItem({
       name: 'Installed',
@@ -236,6 +237,20 @@ function Template(args: any) {
       />
       <Box pad="large">
         {activeUrl}
+        <button
+          type="button"
+          style={{ marginTop: '1rem' }}
+          onClick={() => setActiveUrl('/explore')}
+        >
+          Go to /explore
+        </button>
+        <button
+          type="button"
+          style={{ marginTop: '1rem' }}
+          onClick={() => setActiveUrl('/explore/public')}
+        >
+          Go to /explore/public
+        </button>
       </Box>
     </Box>
   )

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -16,6 +16,7 @@ type SidebarItem = {
   Icon?: ComponentType<IconProps>
   onClick?: () => any
   items?: SidebarItem[]
+  matchedUrl?: RegExp
 }
 
 type SidebarProps = {
@@ -192,7 +193,7 @@ function Sidebar({
 
   function getIdForUrl(items: SidebarItem[], url: string): string | null {
     for (const item of items) {
-      if (item.url === url) return getId(item)
+      if (item.url === url || (item.matchedUrl instanceof RegExp && item.matchedUrl.test(url))) return getId(item)
 
       if (Array.isArray(item.items) && item.items.length > 0) {
         const id = getIdForUrl(item.items, url)


### PR DESCRIPTION
To match the active item based on a regex.

Useful for determining the 'Explore' active state based on multiple URLs: '/explore', /explore/foo'