### PR TITLE
Use forwardRef in every component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,8 +39,8 @@
       "peerDependencies": {
         "@emotion/react": "*",
         "@emotion/styled": "*",
-        "honorable": ">=0.76.0",
-        "honorable-theme-default": ">=0.44.0",
+        "honorable": ">=0.83.0",
+        "honorable-theme-default": ">=0.45.0",
         "react": ">=16.0.0",
         "react-dom": ">=16.0.0"
       }
@@ -19387,12 +19387,6 @@
       "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
       "dev": true
     },
-    "node_modules/flexpad": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/flexpad/-/flexpad-4.0.1.tgz",
-      "integrity": "sha512-rieLlaL38KtAoDSTMlx03TU+552Lup5RVHDrOVRKqQhSRqTEviTli99nDgJ8YniyD+5mGwBreL33xyyLL8Trtg==",
-      "peer": true
-    },
     "node_modules/flush-write-stream": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
@@ -20568,14 +20562,13 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/honorable": {
-      "version": "0.76.0",
-      "resolved": "https://registry.npmjs.org/honorable/-/honorable-0.76.0.tgz",
-      "integrity": "sha512-rOANjeWJXrhryjuH0Nv8tg7FQTy3KzBZGXynIuJ1oLiK1oN1i1N6xmzxCRTC78raBA2DGiag0yfmqYsnly/K7Q==",
+      "version": "0.83.0",
+      "resolved": "https://registry.npmjs.org/honorable/-/honorable-0.83.0.tgz",
+      "integrity": "sha512-yahHnsjXyw0MsnILEfkw5TX9EB7STVga2rV6CxCcQ7xxEH0DJHC+5pVLKWeH2JRtbzjAnuQtjl/t1bgExTvw4A==",
       "peer": true,
       "dependencies": {
         "@emotion/is-prop-valid": "^1.1.2",
         "@floating-ui/react-dom": "^0.7.0",
-        "flexpad": "^4.0.1",
         "lodash.merge": "^4.6.2",
         "lodash.mergewith": "^4.6.2",
         "prop-types": "^15.8.1",
@@ -20590,9 +20583,9 @@
       }
     },
     "node_modules/honorable-theme-default": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/honorable-theme-default/-/honorable-theme-default-0.44.0.tgz",
-      "integrity": "sha512-ovVZ5doN7sIAryWqYvVtv4Tb1+rlxhht/ueTQ6MFFdx+UDLArqe5NZ6RksKFvjdyb1u86XfczJi6B7G5vKX+fA==",
+      "version": "0.45.0",
+      "resolved": "https://registry.npmjs.org/honorable-theme-default/-/honorable-theme-default-0.45.0.tgz",
+      "integrity": "sha512-jZMojeWiN1k2yJaP7v0dhV5pOppuvt2HzOYHqa20QhAlH4pd5bgycqKa9fScT5PYiQcSFCoA0YYt1so/wKFfLg==",
       "peer": true,
       "peerDependencies": {
         "@emotion/react": ">=10.0.0"
@@ -50623,12 +50616,6 @@
       "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
       "dev": true
     },
-    "flexpad": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/flexpad/-/flexpad-4.0.1.tgz",
-      "integrity": "sha512-rieLlaL38KtAoDSTMlx03TU+552Lup5RVHDrOVRKqQhSRqTEviTli99nDgJ8YniyD+5mGwBreL33xyyLL8Trtg==",
-      "peer": true
-    },
     "flush-write-stream": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
@@ -51553,14 +51540,13 @@
       }
     },
     "honorable": {
-      "version": "0.76.0",
-      "resolved": "https://registry.npmjs.org/honorable/-/honorable-0.76.0.tgz",
-      "integrity": "sha512-rOANjeWJXrhryjuH0Nv8tg7FQTy3KzBZGXynIuJ1oLiK1oN1i1N6xmzxCRTC78raBA2DGiag0yfmqYsnly/K7Q==",
+      "version": "0.83.0",
+      "resolved": "https://registry.npmjs.org/honorable/-/honorable-0.83.0.tgz",
+      "integrity": "sha512-yahHnsjXyw0MsnILEfkw5TX9EB7STVga2rV6CxCcQ7xxEH0DJHC+5pVLKWeH2JRtbzjAnuQtjl/t1bgExTvw4A==",
       "peer": true,
       "requires": {
         "@emotion/is-prop-valid": "^1.1.2",
         "@floating-ui/react-dom": "^0.7.0",
-        "flexpad": "^4.0.1",
         "lodash.merge": "^4.6.2",
         "lodash.mergewith": "^4.6.2",
         "prop-types": "^15.8.1",
@@ -51569,9 +51555,9 @@
       }
     },
     "honorable-theme-default": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/honorable-theme-default/-/honorable-theme-default-0.44.0.tgz",
-      "integrity": "sha512-ovVZ5doN7sIAryWqYvVtv4Tb1+rlxhht/ueTQ6MFFdx+UDLArqe5NZ6RksKFvjdyb1u86XfczJi6B7G5vKX+fA==",
+      "version": "0.45.0",
+      "resolved": "https://registry.npmjs.org/honorable-theme-default/-/honorable-theme-default-0.45.0.tgz",
+      "integrity": "sha512-jZMojeWiN1k2yJaP7v0dhV5pOppuvt2HzOYHqa20QhAlH4pd5bgycqKa9fScT5PYiQcSFCoA0YYt1so/wKFfLg==",
       "peer": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -59,8 +59,8 @@
     "typescript": "^4.6.4"
   },
   "peerDependencies": {
-    "honorable": ">=0.76.0",
-    "honorable-theme-default": ">=0.44.0",
+    "honorable": ">=0.83.0",
+    "honorable-theme-default": ">=0.45.0",
     "@emotion/react": "*",
     "@emotion/styled": "*",
     "react": ">=16.0.0",

--- a/src/components/Alert.tsx
+++ b/src/components/Alert.tsx
@@ -1,3 +1,4 @@
+import { Ref, forwardRef } from 'react'
 import { Div, DivProps, Flex, P } from 'honorable'
 import PropTypes from 'prop-types'
 
@@ -7,7 +8,7 @@ import ErrorIcon from './icons/ErrorIcon'
 import CloseIcon from './icons/CloseIcon'
 
 type AlertProps = DivProps & {
-  severity?: 'success' | 'warning' | 'error' | 'info'
+  severity?: 'success' | 'warning' | 'error' | 'info' | string
   title?: string
   onClose?: () => void
 }
@@ -40,12 +41,13 @@ const severityToIcon = {
   info: StatusOkIcon,
 }
 
-function Alert({ children, severity = 'info', title = '', onClose, ...props }: AlertProps) {
+function AlertRef({ children, severity = 'info', title = '', onClose, ...props }: AlertProps, ref: Ref<any>) {
   const AlertIcon = severityToIcon[severity] || StatusOkIcon
   const color = severityToColor[severity] || 'primary'
 
   return (
     <Flex
+      ref={ref}
       align="center"
       position="relative"
       py={1}
@@ -72,6 +74,7 @@ function Alert({ children, severity = 'info', title = '', onClose, ...props }: A
         size={24}
         color={color}
         flexShrink={0}
+
       />
       <Div ml={2}>
         {!!title && (
@@ -90,6 +93,8 @@ function Alert({ children, severity = 'info', title = '', onClose, ...props }: A
     </Flex>
   )
 }
+
+const Alert = forwardRef(AlertRef)
 
 Alert.propTypes = propTypes
 

--- a/src/components/Avatar.tsx
+++ b/src/components/Avatar.tsx
@@ -1,3 +1,4 @@
+import { Ref, forwardRef } from 'react'
 import { Flex, FlexProps, Img, P } from 'honorable'
 import PropTypes from 'prop-types'
 
@@ -20,7 +21,7 @@ function extractInitials(name: string) {
   return words.map(word => word[0]).filter((_, i, a) => i === 0 || i === a.length - 1).join('').toUpperCase()
 }
 
-function Avatar({ name = '', imageUrl = '', size = 44, ...props }: AvatarProps) {
+function AvatarRef({ name = '', imageUrl = '', size = 44, ...props }: AvatarProps, ref: Ref<any>) {
   function renderName() {
     return (
       <P
@@ -45,6 +46,7 @@ function Avatar({ name = '', imageUrl = '', size = 44, ...props }: AvatarProps) 
 
   return (
     <Flex
+      ref={ref}
       align="center"
       justify="center"
       backgroundColor={imageUrl ? 'transparent' : 'accent-blue'}
@@ -60,6 +62,8 @@ function Avatar({ name = '', imageUrl = '', size = 44, ...props }: AvatarProps) 
     </Flex>
   )
 }
+
+const Avatar = forwardRef(AvatarRef)
 
 Avatar.propTypes = propTypes
 

--- a/src/components/Divider.tsx
+++ b/src/components/Divider.tsx
@@ -1,3 +1,4 @@
+import { Ref, forwardRef } from 'react'
 import { Div, Flex, FlexProps, P } from 'honorable'
 import PropTypes from 'prop-types'
 
@@ -9,9 +10,10 @@ const propTypes = {
   text: PropTypes.string,
 }
 
-function Divider({ text = 'or', ...props }: AlertProps) {
+function DividerRef({ text = 'or', ...props }: AlertProps, ref: Ref<any>) {
   return (
     <Flex
+      ref={ref}
       align="center"
       {...props}
     >
@@ -36,6 +38,8 @@ function Divider({ text = 'or', ...props }: AlertProps) {
     </Flex>
   )
 }
+
+const Divider = forwardRef(DividerRef)
 
 Divider.propTypes = propTypes
 

--- a/src/components/FormField.tsx
+++ b/src/components/FormField.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren, useEffect, useRef, useState } from 'react'
+import { PropsWithChildren, Ref, forwardRef, useEffect, useRef, useState } from 'react'
 import { Div, DivProps, P } from 'honorable'
 import PropTypes from 'prop-types'
 
@@ -18,7 +18,7 @@ const propTypes = {
   required: PropTypes.bool,
 }
 
-function FormField({ children, label, caption, valid, error, required, ...props }: FormFieldProps) {
+function FormFieldRef({ children, label, caption, valid, error, required, ...props }: FormFieldProps, ref: Ref<any>) {
   const labelRef = useRef<HTMLParagraphElement>()
   const [captionMaxWidth, setCaptionMaxWidth] = useState('auto')
 
@@ -32,6 +32,7 @@ function FormField({ children, label, caption, valid, error, required, ...props 
 
   return (
     <Div
+      ref={ref}
       position="relative"
       {...props}
     >
@@ -59,6 +60,8 @@ function FormField({ children, label, caption, valid, error, required, ...props 
     </Div>
   )
 }
+
+const FormField = forwardRef(FormFieldRef)
 
 FormField.propTypes = propTypes
 

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -1,3 +1,4 @@
+import { Ref, forwardRef } from 'react'
 import { Input as HonorableInput, InputProps as HonorableInputProps } from 'honorable'
 import PropTypes from 'prop-types'
 
@@ -11,7 +12,7 @@ const propTypes = {
   error: PropTypes.bool,
 }
 
-function Input({ valid = false, error = false, ...props }: InputProps) {
+function InputRef({ valid = false, error = false, ...props }: InputProps, ref: Ref<any>) {
   const style = {
     width: '100%',
     borderColor: error ? 'red' : valid ? 'primary' : 'border',
@@ -22,11 +23,14 @@ function Input({ valid = false, error = false, ...props }: InputProps) {
 
   return (
     <HonorableInput
+      ref={ref}
       {...style}
       {...props}
     />
   )
 }
+
+const Input = forwardRef(InputRef)
 
 Input.propTypes = propTypes
 

--- a/src/components/InstalledLabel.tsx
+++ b/src/components/InstalledLabel.tsx
@@ -1,5 +1,6 @@
 import { Flex, FlexProps, P } from 'honorable'
 import PropTypes from 'prop-types'
+import { Ref, forwardRef } from 'react'
 
 import CheckOutlineIcon from './icons/CheckOutlineIcon'
 
@@ -11,9 +12,10 @@ const propTypes = {
   label: PropTypes.string,
 }
 
-function InstalledLabel({ label = 'Installed', ...props }: InstalledLabelProps) {
+function InstalledLabelRef({ label = 'Installed', ...props }: InstalledLabelProps, ref: Ref<any>) {
   return (
     <Flex
+      ref={ref}
       align="center"
       {...props}
     >
@@ -27,6 +29,8 @@ function InstalledLabel({ label = 'Installed', ...props }: InstalledLabelProps) 
     </Flex>
   )
 }
+
+const InstalledLabel = forwardRef(InstalledLabelRef)
 
 InstalledLabel.propTypes = propTypes
 

--- a/src/components/RepositoryCard.tsx
+++ b/src/components/RepositoryCard.tsx
@@ -1,5 +1,6 @@
 import { Div, DivProps, Flex, Img, P } from 'honorable'
 import PropTypes from 'prop-types'
+import { Ref, forwardRef } from 'react'
 
 import InstalledLabel from './InstalledLabel'
 
@@ -19,7 +20,7 @@ const propTypes = {
   imageUrl: PropTypes.string,
 }
 
-function RepositoryCard({
+function RepositoryCardRef({
   featured = false,
   installed = false,
   title,
@@ -27,7 +28,9 @@ function RepositoryCard({
   imageUrl,
   children,
   ...props
-}: RepositoryCardProps) {
+}: RepositoryCardProps,
+ref: Ref<any>
+) {
 
   function renderContent() {
     return (
@@ -52,6 +55,7 @@ function RepositoryCard({
   function renderFeatured() {
     return (
       <Flex
+        ref={ref}
         p={1}
         justify="flex-start"
         align="flex-start"
@@ -94,6 +98,7 @@ function RepositoryCard({
   function renderRegular() {
     return (
       <Div
+        ref={ref}
         p={1}
         borderRadius={4}
         border="1px solid border"
@@ -129,6 +134,8 @@ function RepositoryCard({
 
   return featured ? renderFeatured() : renderRegular()
 }
+
+const RepositoryCard = forwardRef(RepositoryCardRef)
 
 RepositoryCard.propTypes = propTypes
 

--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -1,13 +1,24 @@
-import { ReactNode } from 'react'
+import { ReactNode, Ref, forwardRef } from 'react'
 import { Select as HonorableSelect, SelectProps as HonorableSelectProps, MenuItem } from 'honorable'
+import PropTypes from 'prop-types'
 
 type SelectProps = HonorableSelectProps & {
   items: Array<{ label: ReactNode, value: any }>
 }
 
-function Select({ items, ...props }: SelectProps) {
+const propTypes = {
+  items: PropTypes.arrayOf(
+    PropTypes.shape({
+      label: PropTypes.node.isRequired,
+      value: PropTypes.any.isRequired,
+    }).isRequired
+  ).isRequired,
+}
+
+function SelectRef({ items, ...props }: SelectProps, ref: Ref<any>) {
   return (
     <HonorableSelect
+      ref={ref}
       {...props}
     >
       {items.map(({ value, label }) => (
@@ -18,4 +29,10 @@ function Select({ items, ...props }: SelectProps) {
     </HonorableSelect>
   )
 }
+
+const Select = forwardRef(SelectRef)
+
+// @ts-ignore
+Select.propTypes = propTypes
+
 export default Select

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { ComponentType, Fragment, MouseEvent, ReactNode, useCallback, useEffect, useRef, useState } from 'react'
+import { ComponentType, Fragment, MouseEvent, ReactNode, Ref, forwardRef, useCallback, useEffect, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 import styled from '@emotion/styled'
 import { Div, DivProps, Flex, P, useTheme } from 'honorable'
@@ -87,11 +87,13 @@ const ChildrenContainer = styled(Div)`
   }
 `
 
-function Sidebar({
+function SidebarRef({
   items = [],
   activeUrl = '',
   ...props
-}: SidebarProps) {
+}: SidebarProps,
+ref: Ref<any>
+) {
   const activeItem = getItemForUrl(items, activeUrl)
   const activeId = getId(activeItem)
   const theme = useTheme()
@@ -300,6 +302,7 @@ function Sidebar({
 
   return (
     <Div
+      ref={ref}
       transition="width 300ms ease"
       width={collapsed ? 74 : 256 - 32}
       height="100%"
@@ -364,6 +367,8 @@ function Sidebar({
     </Div>
   )
 }
+
+const Sidebar = forwardRef(SidebarRef)
 
 Sidebar.propTypes = propTypes
 

--- a/src/components/Switch.tsx
+++ b/src/components/Switch.tsx
@@ -1,3 +1,4 @@
+import { Ref, forwardRef } from 'react'
 import { Switch as HonorableSwitch, SwitchProps as HonorableSwitchProps } from 'honorable'
 
 import CheckIcon from './icons/CheckIcon'
@@ -7,9 +8,10 @@ type SwitchProps = HonorableSwitchProps
 
 const propTypes = {}
 
-function Switch(props: SwitchProps) {
+function SwitchRef(props: SwitchProps, ref: Ref<any>) {
   return (
     <HonorableSwitch
+      ref={ref}
       backgroundColor={props.checked ? 'success' : 'error'}
       uncheckedBackground={(
         <CloseIcon
@@ -27,6 +29,8 @@ function Switch(props: SwitchProps) {
     />
   )
 }
+
+const Switch = forwardRef(SwitchRef)
 
 Switch.propTypes = propTypes
 

--- a/src/components/Tag.tsx
+++ b/src/components/Tag.tsx
@@ -1,12 +1,14 @@
+import { Ref, forwardRef } from 'react'
 import { Flex, FlexProps, P } from 'honorable'
 
 type TagProps = FlexProps
 
 const propTypes = {}
 
-function Tag({ children, ...props }: TagProps) {
+function TagRef({ children, ...props }: TagProps, ref: Ref<any>) {
   return (
     <Flex
+      ref={ref}
       py={0.25}
       px={0.5}
       align="center"
@@ -21,6 +23,8 @@ function Tag({ children, ...props }: TagProps) {
     </Flex>
   )
 }
+
+const Tag = forwardRef(TagRef)
 
 Tag.propTypes = propTypes
 

--- a/src/components/Token.tsx
+++ b/src/components/Token.tsx
@@ -1,3 +1,4 @@
+import { Ref, forwardRef } from 'react'
 import { Flex, FlexProps, P } from 'honorable'
 import PropTypes from 'prop-types'
 
@@ -11,9 +12,10 @@ const propTypes = {
   onClose: PropTypes.func,
 }
 
-function Token({ children, onClose = () => {}, ...props }: TokenProps) {
+function TokenRef({ children, onClose = () => {}, ...props }: TokenProps, ref: Ref<any>) {
   return (
     <Flex
+      ref={ref}
       pl={0.5}
       display="inline-flex"
       minHeight={28}
@@ -42,6 +44,8 @@ function Token({ children, onClose = () => {}, ...props }: TokenProps) {
     </Flex>
   )
 }
+
+const Token = forwardRef(TokenRef)
 
 Token.propTypes = propTypes
 

--- a/src/components/UserCard.tsx
+++ b/src/components/UserCard.tsx
@@ -1,3 +1,4 @@
+import { Ref, forwardRef } from 'react'
 import { Div, Flex, FlexProps, P } from 'honorable'
 import PropTypes from 'prop-types'
 
@@ -17,9 +18,10 @@ const propTypes = {
   }),
 }
 
-function UserCard({ user = {}, ...props }: UserCardProps) {
+function UserCardRef({ user = {}, ...props }: UserCardProps, ref: Ref<any>) {
   return (
     <Flex
+      ref={ref}
       align="center"
       {...props}
     >
@@ -47,6 +49,8 @@ function UserCard({ user = {}, ...props }: UserCardProps) {
     </Flex>
   )
 }
+
+const UserCard = forwardRef(UserCardRef)
 
 UserCard.propTypes = propTypes
 

--- a/src/components/icons/createIcon.tsx
+++ b/src/components/icons/createIcon.tsx
@@ -1,24 +1,39 @@
-import { ReactNode } from 'react'
+import { ReactNode, Ref, forwardRef } from 'react'
 import { Icon as HonorableIcon, IconProps as HonorableIconProps, useTheme } from 'honorable'
+import PropTypes from 'prop-types'
 
-export type IconProps = HonorableIconProps & {
+type IconBaseProps = {
   size?: number
   color?: string
 }
 
-function createIcon(render: (props: IconProps) => ReactNode) {
-  function Icon({ size = 16, color = 'white', ...props }) {
+export type IconProps = HonorableIconProps & IconBaseProps
+
+const propTypes = {
+  size: PropTypes.number,
+  color: PropTypes.string,
+}
+
+function createIcon(render: (props: IconBaseProps) => ReactNode) {
+  function IconRef({ size = 16, color = 'white', ...props }: IconProps, ref: Ref<any>) {
     const theme = useTheme()
     const workingColor = theme.utils.resolveColorString(color)
 
     return (
-      <HonorableIcon {...props}>
+      <HonorableIcon
+        ref={ref}
+        {...props}
+      >
         {render({ size, color: workingColor })}
       </HonorableIcon>
     )
   }
 
-  return Icon
+  const ForwardedIcon = forwardRef(IconRef)
+
+  ForwardedIcon.propTypes = propTypes
+
+  return ForwardedIcon
 }
 
 export default createIcon


### PR DESCRIPTION
To pass references from a parent component.
It's a best practice that was on my to-do list for a long time.
It also enables us to use a tooltip (honorable or other) around our components. 
Many UI libs such as MUI, Chakra or Honorable require refs to be passed to use the Tooltip component.