### PR TITLE
Bump version to fix CI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pluralsh-design-system",
-  "version": "1.113.0",
+  "version": "1.114.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pluralsh-design-system",
-      "version": "1.113.0",
+      "version": "1.114.0",
       "dependencies": {
         "prop-types": "^15.8.1"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pluralsh-design-system",
-  "version": "1.112.0",
+  "version": "1.113.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pluralsh-design-system",
-      "version": "1.112.0",
+      "version": "1.113.0",
       "dependencies": {
         "prop-types": "^15.8.1"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pluralsh-design-system",
-  "version": "1.113.0",
+  "version": "1.114.0",
   "description": "Pluralsh Design System",
   "main": "dist/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pluralsh-design-system",
-  "version": "1.112.0",
+  "version": "1.113.0",
   "description": "Pluralsh Design System",
   "main": "dist/index.js",
   "files": [


### PR DESCRIPTION
https://www.npmjs.com/package/pluralsh-design-system contains v1.113.0, this bumps version in the package.json to avoid errors like https://github.com/pluralsh/design-system/runs/7234261241?check_suite_focus=true.