### PR TITLE
Add breakpoints to theme

### DIFF
--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -144,6 +144,11 @@ const spacers = {
 export default mergeTheme(defaultTheme, {
   name: 'Plural',
   mode: 'dark',
+  breakpoints: {
+    // We'll add mobile breakpoints later
+    desktop: 1280,
+    'desktop-large': 1440,
+  },
   colors: {
     // Base palette,
     blue,


### PR DESCRIPTION
FYI, Honorable allows you to do:
```jsx
<Div
  backgroundColor-desktop-up="white" // Over desktop screens
  backgroundColor-desktop-down="blue" // Below desktop screens
  backgroundColor-desktop-exact="red" // Only desktop screens
  display="block"
  display-desktop="flex" // Same a display-desktop-exact
  width-some-other-breakpoint="100%" // someOtherBreakpoint is a custom breakpoint
/>
```

This PR sets two breakpoints:
- desktop
- desktop-large