### PR TITLE
Don’t use absolute imports

### DIFF
--- a/src/components/RepositoryCard.tsx
+++ b/src/components/RepositoryCard.tsx
@@ -1,7 +1,8 @@
-import RepositoryIcon from '@src/components/RepositoryIcon'
 import { Div, DivProps, Flex, H2, H3, P, Span } from 'honorable'
 import PropTypes from 'prop-types'
 import { Ref, forwardRef } from 'react'
+
+import RepositoryIcon from '../../src/components/RepositoryIcon'
 
 import Chip from './Chip'
 


### PR DESCRIPTION
Using absolute `@src/` imports causes errors when using the library in the plural app. We should only use relative paths until/unless we figure out a way to have absolute paths resolve properly on build.