### PR TITLE
Unexport tag component

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -139,7 +139,6 @@ export {
   TabListStateProps,
   TabPanel,
 } from './components/TabList'
-export { default as Tag } from './components/Tag'
 export { default as TipCarousel } from './components/TipCarousel'
 export { default as Token } from './components/Token'
 export { default as UserCard } from './components/UserCard'


### PR DESCRIPTION
This reverts my last change. As discussed on Slack this component should not be used anymore.