### PR TITLE
Update chip component

### DIFF
--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -30,7 +30,7 @@ const hueToHoverBGColor: {
 } = {
   default: 'fill-one-hover',
   lighter: 'fill-two-hover',
-  lightest: 'fill-three',
+  lightest: 'fill-three-hover',
 }
 
 const hueToSelectedBGColor: {
@@ -38,7 +38,7 @@ const hueToSelectedBGColor: {
 } = {
   default: 'fill-one-selected',
   lighter: 'fill-two-selected',
-  lightest: 'fill-three',
+  lightest: 'fill-three-selected',
 }
 
 const cornerSizeToBorderRadius: {

--- a/src/components/Chip.tsx
+++ b/src/components/Chip.tsx
@@ -1,19 +1,14 @@
 import { Flex, FlexProps, Spinner } from 'honorable'
 import PropTypes from 'prop-types'
-import {
-  Dispatch, ReactElement, Ref, forwardRef,
-} from 'react'
+import { ReactElement, Ref, forwardRef } from 'react'
 
 import Card, { CardProps } from './Card'
-import CloseIcon from './icons/CloseIcon'
 
 type ChipProps = FlexProps & {
   size?: 'small' | 'medium' | 'large' | string
   severity?: 'neutral' | 'info' | 'success' | 'warning' | 'error' | 'critical' | string
   icon?: ReactElement,
   loading?: boolean,
-  removable?: boolean,
-  onClick?: Dispatch<void>,
 } & CardProps
 
 const propTypes = {
@@ -22,8 +17,6 @@ const propTypes = {
   hue: PropTypes.oneOf(['default', 'lighter', 'lightest']),
   icon: PropTypes.element,
   loading: PropTypes.bool,
-  removable: PropTypes.bool,
-  onClick: PropTypes.func,
 }
 
 const severityToColor = {
@@ -47,8 +40,6 @@ function ChipRef({
   severity = 'neutral',
   hue = 'default',
   loading = false,
-  removable = false,
-  onClick = null,
   icon,
   ...props
 }: ChipProps, ref: Ref<any>) {
@@ -64,7 +55,6 @@ function ChipRef({
       alignItems="center"
       display="inline-flex"
       maxHeight={sizeToHeight[size]}
-      onClick={removable ? null : onClick}
       {...props}
     >
       {loading && (
@@ -91,16 +81,6 @@ function ChipRef({
         gap={4}
       >
         {children}
-        {removable && onClick && (
-          <CloseIcon
-            alignSelf="center"
-            onClick={onClick}
-            width={16}
-            height={16}
-            size={size === 'small' ? 8 : 10}
-            cursor="pointer"
-          />
-        )}
       </Flex>
     </Card>
   )

--- a/src/components/Chip.tsx
+++ b/src/components/Chip.tsx
@@ -1,16 +1,19 @@
-import { ReactElement, Ref, forwardRef } from 'react'
-import {
-  FlexProps, P, Spinner,
-} from 'honorable'
+import { Flex, FlexProps, Spinner } from 'honorable'
 import PropTypes from 'prop-types'
+import {
+  Dispatch, ReactElement, Ref, forwardRef,
+} from 'react'
 
 import Card, { CardProps } from './Card'
+import CloseIcon from './icons/CloseIcon'
 
 type ChipProps = FlexProps & {
   size?: 'small' | 'medium' | 'large' | string
   severity?: 'neutral' | 'info' | 'success' | 'warning' | 'error' | 'critical' | string
   icon?: ReactElement,
-  loading?: boolean
+  loading?: boolean,
+  removable?: boolean,
+  onClick?: Dispatch<void>,
 } & CardProps
 
 const propTypes = {
@@ -19,6 +22,8 @@ const propTypes = {
   hue: PropTypes.oneOf(['default', 'lighter', 'lightest']),
   icon: PropTypes.element,
   loading: PropTypes.bool,
+  removable: PropTypes.bool,
+  onClick: PropTypes.func,
 }
 
 const severityToColor = {
@@ -42,6 +47,8 @@ function ChipRef({
   severity = 'neutral',
   hue = 'default',
   loading = false,
+  removable = false,
+  onClick = null,
   icon,
   ...props
 }: ChipProps, ref: Ref<any>) {
@@ -57,6 +64,7 @@ function ChipRef({
       alignItems="center"
       display="inline-flex"
       maxHeight={sizeToHeight[size]}
+      onClick={removable ? null : onClick}
       {...props}
     >
       {loading && (
@@ -73,16 +81,27 @@ function ChipRef({
           color={col}
         />
       )}
-      <P
+      <Flex
         body2
         color={col}
         fontSize={size === 'small' ? 12 : 14}
         fontWeight={size === 'small' ? 400 : 600}
         lineHeight={size === 'small' ? '16px' : '20px'}
         height={size === 'small' ? '16px' : '20px'}
+        gap={4}
       >
         {children}
-      </P>
+        {removable && onClick && (
+          <CloseIcon
+            alignSelf="center"
+            onClick={onClick}
+            width={16}
+            height={16}
+            size={size === 'small' ? 8 : 10}
+            cursor="pointer"
+          />
+        )}
+      </Flex>
     </Card>
   )
 }

--- a/src/components/Token.tsx
+++ b/src/components/Token.tsx
@@ -1,18 +1,41 @@
-import { Ref, forwardRef } from 'react'
 import { Flex, FlexProps } from 'honorable'
 import PropTypes from 'prop-types'
+import { Ref, forwardRef } from 'react'
 
 import CloseIcon from './icons/CloseIcon'
 
+type TokenHue = 'default' | 'lighter' | 'lightest' | string
+
 type TokenProps = FlexProps & {
   onClose?: () => void
+  hue?: TokenHue
 }
 
 const propTypes = {
   onClose: PropTypes.func,
+  hue: PropTypes.string,
 }
 
-function TokenRef({ children, onClose = () => {}, ...props }: TokenProps, ref: Ref<any>) {
+const hueToBGColor: { [key in TokenHue]: string } = {
+  default: 'fill-one',
+  lighter: 'fill-two',
+  lightest: 'fill-three',
+}
+
+const hueToHoverBGColor: {
+  [key in TokenHue]: string
+} = {
+  default: 'fill-one-hover',
+  lighter: 'fill-two-hover',
+  lightest: 'fill-three-hover',
+}
+
+function TokenRef({
+  children, hue = hueToBGColor.default, onClose = () => {}, ...props
+}: TokenProps, ref: Ref<any>) {
+  const background = hueToBGColor[hue]
+  const hover = hueToHoverBGColor[hue]
+
   return (
     <Flex
       ref={ref}
@@ -21,10 +44,10 @@ function TokenRef({ children, onClose = () => {}, ...props }: TokenProps, ref: R
       display="inline-flex"
       align="center"
       borderRadius="medium"
-      backgroundColor="fill-one"
+      backgroundColor={background}
       overflow="hidden"
       cursor="pointer"
-      hoverIndicator="fill-one-hover"
+      hoverIndicator={hover}
       onClick={onClose}
       {...props}
     >

--- a/src/components/Token.tsx
+++ b/src/components/Token.tsx
@@ -47,7 +47,7 @@ function TokenRef({
       backgroundColor={background}
       overflow="hidden"
       cursor="pointer"
-      hoverIndicator={hover}
+      _hover={{ backgroundColor: hover }}
       onClick={onClose}
       {...props}
     >

--- a/src/components/Token.tsx
+++ b/src/components/Token.tsx
@@ -22,7 +22,6 @@ function TokenRef({ children, onClose = () => {}, ...props }: TokenProps, ref: R
       align="center"
       borderRadius="medium"
       backgroundColor="fill-one"
-      border="1px solid border"
       overflow="hidden"
       cursor="pointer"
       hoverIndicator="fill-one-hover"

--- a/src/stories/Chip.stories.tsx
+++ b/src/stories/Chip.stories.tsx
@@ -536,6 +536,4 @@ function Template(args: any) {
 export const Default = Template.bind({})
 Default.args = {
   hue: 'default',
-  removable: false,
-  onClick: () => alert('remove'),
 }

--- a/src/stories/Chip.stories.tsx
+++ b/src/stories/Chip.stories.tsx
@@ -536,4 +536,6 @@ function Template(args: any) {
 export const Default = Template.bind({})
 Default.args = {
   hue: 'default',
+  removable: false,
+  onClick: () => alert('remove'),
 }

--- a/src/stories/Token.stories.tsx
+++ b/src/stories/Token.stories.tsx
@@ -3,6 +3,14 @@ import Token from '../components/Token'
 export default {
   title: 'Token',
   component: Token,
+  argTypes: {
+    hue: {
+      options: ['default', 'lighter', 'lightest'],
+      control: {
+        type: 'select',
+      },
+    },
+  },
 }
 
 function Template(args: any) {
@@ -17,4 +25,5 @@ export const Default = Template.bind({})
 
 Default.args = {
   children: 'jane.smith@plural.sh',
+  hue: 'default',
 }

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -169,6 +169,8 @@ export default mergeTheme(defaultTheme, {
     'fill-two-hover': grey[775],
     'fill-two-selected': grey[725],
     'fill-three': grey[750],
+    'fill-three-hover': grey[725],
+    'fill-three-selected': grey[675],
     // Action,
     'action-primary': blue[400],
     'action-primary-hover': blue[350],


### PR DESCRIPTION
- Used `flex` instead of `p` and element that embeds children (it was throwing errors that `p` cannot have children`
- Updated `Token` component as in the design it does not have border. [Ref](https://www.figma.com/file/kZ69OGXTQe3Gu0wzGdDyoO/Marketplace-Tab?node-id=910%3A34710).
- Added `hue` property to the `Token` component