### PR TITLE
Require version updates in pull requests

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,8 +12,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16.15.0
-      - run: |
-          yarn install --immutable
+      - run: yarn --immutable
       - run: yarn build:storybook
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
@@ -32,13 +31,8 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16.15.0
-      - run: |
-          yarn install --immutable
-      - run: git config --global user.email "dherault@gmail.com" && git config --global user.name "David Hérault"
-      # TODO: include tests here
-      - run: npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: yarn --immutable
       - run: yarn clean && yarn build
-      - run: npm version minor && npm publish
-      - run: git pull && git push
+      - uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,15 @@
 name: CI
 on: pull_request
 jobs:
+  version:
+    name: Check version
+    runs-on: ubuntu-latest
+    steps:
+      - id: check
+        uses: EndBug/version-check@v1
+        with:
+          file-url: https://unpkg.com/pluralsh-design-system@latest/package.json
+          static-checking: localIsNew
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ jobs:
     name: Check version
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - id: check
         uses: EndBug/version-check@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,12 @@ jobs:
           node-version: 16.15.0
       - uses: flood-io/is-published-on-npm@v1
         id: check
+      - run: |
+          echo "Local version from package.json is ${{ steps.check.outputs.version }}"
+          echo "Published version from npm registry is $(npm view . version)"
       - if: ${{ steps.check.outputs.published == 'true' }}
         run: |
-          echo "${{ steps.check.outputs.version }} is already published on npm"
-          echo "Update package version to be bigger than $(npm view pluralsh-design-system version)"
+          echo "This version is already published, update local version to be bigger than published one"
           exit 1
   build:
     name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ jobs:
           diff-search: true
           file-url: https://unpkg.com/pluralsh-design-system@latest/package.json
           static-checking: localIsNew
+      - name: Log when unchanged
+        if: steps.check.outputs.changed == 'false'
+        run: 'echo "Update version in package.json"'
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: kriasoft/check-version@v1
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16.15.0
+      - uses: flood-io/is-published-on-npm@v1
+        id: published
+      - if: ${{ steps.published.outputs.published == 'true' }}
+        run: |
+          echo '${{ steps.published.outputs.version }} is already published on npm, update it in package.json'
+          exit 1
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - if: ${{ steps.check.outputs.published == 'true' }}
         run: |
           echo '${{ steps.check.outputs.version }} is already published on npm'
-          echo 'Update package version to version bigger than ${{ steps.npm.output }}'
+          echo 'Update package version to version bigger than ${{ steps.npm.outputs.stdout }}'
           exit 1
   build:
     name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,13 @@ jobs:
         with:
           node-version: 16.15.0
       - uses: flood-io/is-published-on-npm@v1
-        id: published
-      - if: ${{ steps.published.outputs.published == 'true' }}
+        id: check
+      - run: npm view pluralsh-design-system version
+        id: npm
+      - if: ${{ steps.check.outputs.published == 'true' }}
         run: |
-          echo '${{ steps.published.outputs.version }} is already published on npm, update it in package.json'
+          echo '${{ steps.check.outputs.version }} is already published on npm'
+          echo 'Update package version to version bigger than ${{ steps.npm.output }}'
           exit 1
   build:
     name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ jobs:
       - id: check
         uses: EndBug/version-check@v1
         with:
+          diff-search: true
           file-url: https://unpkg.com/pluralsh-design-system@latest/package.json
           static-checking: localIsNew
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - if: ${{ steps.check.outputs.published == 'true' }}
         run: |
           echo '${{ steps.check.outputs.version }} is already published on npm'
-          echo 'Update package version to version bigger than ${{ steps.npm.outputs.stdout }}'
+          echo 'Update package version to version bigger than ${{ steps.npm.output.stdout }}'
           exit 1
   build:
     name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,10 @@ jobs:
           node-version: 16.15.0
       - uses: flood-io/is-published-on-npm@v1
         id: check
-      - run: npm view pluralsh-design-system version
-        id: npm
       - if: ${{ steps.check.outputs.published == 'true' }}
         run: |
-          echo '${{ steps.check.outputs.version }} is already published on npm'
-          echo 'Update package version to version bigger than ${{ steps.npm.output.stdout }}'
+          echo "${{ steps.check.outputs.version }} is already published on npm"
+          echo "Update package version to be bigger than $(npm view pluralsh-design-system version)"
           exit 1
   build:
     name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,15 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - id: check
-        uses: EndBug/version-check@v1
-        with:
-          diff-search: true
-          file-url: https://unpkg.com/pluralsh-design-system@latest/package.json
-          static-checking: localIsNew
-      - name: Log when unchanged
-        if: steps.check.outputs.changed == 'false'
-        run: 'echo "Update version in package.json"'
+      - uses: kriasoft/check-version@v1
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pluralsh-design-system",
-  "version": "1.144.0",
+  "version": "1.145.0",
   "description": "Pluralsh Design System",
   "main": "dist/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pluralsh-design-system",
-  "version": "1.145.0",
+  "version": "1.143.0",
   "description": "Pluralsh Design System",
   "main": "dist/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pluralsh-design-system",
-  "version": "1.143.0",
+  "version": "1.146.0",
   "description": "Pluralsh Design System",
   "main": "dist/index.js",
   "files": [


### PR DESCRIPTION
## Current problem
CD is no longer able to push changes after version bump and publish because of new branch protection rules. This makes master out of sync. First publish job fails after publishing new version but before commit, all next ones fail during publish as versions are out of sync and it fails to override already published version.

## Changes
- [x] Update CD actions to publish new package versions only if they are not published yet
- [x] Update CI actions to check if version was updated in each pull request
  - [x] Compares versions from local package.json to npm registry
  - [ ] Reruns on each base branch change

If you have any ideas how to make it better let me know. This tries to move away from commits in CD as this can bring some security risks. Now when we would need to add access token to make it work then it would be unsafe.
  
### Example error message
```
Local version from package.json is 1.143.0
Published version from npm registry is 1.145.0

This version is already published, update local version to be bigger than published one
```