### PR TITLE
Update code block styling

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,6 +1,6 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link rel='stylesheet' href='https://highlightjs.org/static/demo/styles/nord.css'/>
+<link rel='stylesheet' href='https://highlightjs.org/static/demo/styles/base16/rebecca.css'/>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
 <style>
   @font-face {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pluralsh-design-system",
-  "version": "1.156.0",
+  "version": "1.157.0",
   "description": "Pluralsh Design System",
   "main": "dist/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pluralsh-design-system",
-  "version": "1.155.0",
+  "version": "1.156.0",
   "description": "Pluralsh Design System",
   "main": "dist/index.js",
   "files": [

--- a/src/components/Code.tsx
+++ b/src/components/Code.tsx
@@ -67,30 +67,41 @@ function CodeRef({ children, language, ...props }: CodeProps) {
     <Card
       onMouseEnter={() => setHover(true)}
       onMouseLeave={() => setHover(false)}
-      minHeight="90px"
       {...props}
     >
-      <Flex position="relative">
-        {hover && (
-          <Button
-            position="absolute"
-            right="24px"
-            top="24px"
-            tertiary
-            backgroundColor="fill-three"
-            _hover={{ backgroundColor: 'fill-one-hover' }}
-            startIcon={copied ? <CheckIcon /> : <CopyIcon />}
-            onClick={handleCopy}
+      <Flex direction="column">
+        {!!language && (
+          <Flex
+            paddingHorizontal="large"
+            paddingVertical="medium"
+            borderBottom="1px solid border"
+            overline
+            color="text-light"
           >
-            {copied ? 'Copied' : 'Copy'}
-          </Button>
+            {language}
+          </Flex>
         )}
         <Flex
           minHeight="90px"
           overflowX="auto"
+          position="relative"
           padding="large"
           alignItems="center"
         >
+          {hover && (
+            <Button
+              position="absolute"
+              right="24px"
+              top="24px"
+              tertiary
+              backgroundColor="fill-three"
+              _hover={{ backgroundColor: 'fill-one-hover' }}
+              startIcon={copied ? <CheckIcon /> : <CopyIcon />}
+              onClick={handleCopy}
+            >
+              {copied ? 'Copied' : 'Copy'}
+            </Button>
+          )}
           <Highlight language={language}>{children}</Highlight>
         </Flex>
       </Flex>

--- a/src/components/Code.tsx
+++ b/src/components/Code.tsx
@@ -39,6 +39,7 @@ function Highlight({ language, children } : HighlightProps) {
       padding="0"
       background="none"
       fontFamily={fontFamilies.mono}
+      lineHeight="22px"
       className={(language && `language-${language}`) || 'nohighlight'}
       ref={codeRef}
     >

--- a/src/stories/Code.stories.tsx
+++ b/src/stories/Code.stories.tsx
@@ -41,6 +41,12 @@ function Template() {
       >
         {goCode}
       </Code>
+      <Code
+        width="400px"
+        language="js"
+      >
+        console.log('test')
+      </Code>
       <Code width="400px">
         One line
       </Code>


### PR DESCRIPTION
It's related to [DES-139](https://linear.app/pluralsh/issue/DES-139/code-blocks). Once it will be merged we'll need to bump version in plural app and update theme in it as well.

<img width="631" alt="Zrzut ekranu 2022-08-17 o 09 14 10" src="https://user-images.githubusercontent.com/2823399/185057609-8b81fbeb-d2d4-47e3-8574-bf7a61289924.png">
