### PR TITLE
Fix tab focus styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pluralsh-design-system",
-  "version": "1.160.0",
+  "version": "1.161.0",
   "description": "Pluralsh Design System",
   "main": "dist/index.js",
   "files": [

--- a/src/components/SubTab.tsx
+++ b/src/components/SubTab.tsx
@@ -1,5 +1,6 @@
 import { ReactNode, Ref, forwardRef } from 'react'
 import { DivProps, Flex, Icon } from 'honorable'
+import { useTheme } from 'styled-components'
 
 type SubTabProps = DivProps & {
   active?: boolean
@@ -9,30 +10,36 @@ type SubTabProps = DivProps & {
 
 const SubTab = forwardRef(({
   startIcon, active, children, ...props
-}: SubTabProps,
-ref: Ref<any>) => (
-  <Flex
-    ref={ref}
-    buttonMedium
-    tabIndex={0}
-    userSelect="none"
-    cursor="pointer"
-    textAlign="center"
-    paddingVertical="xsmall"
-    paddingHorizontal="medium"
-    borderRadius="medium"
-    color={active ? 'text' : 'text-xlight'}
-    backgroundColor={active ? 'fill-zero-selected' : 'none'}
-    _hover={{
-      color: 'text',
-      backgroundColor: active ? 'fill-zero-selected' : 'action-input-hover',
-    }}
-    _focusVisible={{ outline: '1px solid border-outline-focused' }}
-    {...props}
-  >
-    {!!startIcon && <Icon marginRight="small">{startIcon}</Icon>}
-    {children}
-  </Flex>
-))
+}: SubTabProps, ref: Ref<any>) => {
+  const theme = useTheme()
+
+  return (
+    <Flex
+      ref={ref}
+      buttonMedium
+      tabIndex={0}
+      userSelect="none"
+      cursor="pointer"
+      textAlign="center"
+      paddingVertical="xsmall"
+      paddingHorizontal="medium"
+      borderRadius="medium"
+      color={active ? 'text' : 'text-xlight'}
+      backgroundColor={active ? 'fill-zero-selected' : 'none'}
+      _hover={{
+        color: 'text',
+        backgroundColor: active ? 'fill-zero-selected' : 'action-input-hover',
+      }}
+      _focusVisible={{
+        ...theme.partials.focus.default,
+        zIndex: theme.zIndexes.base + 1,
+      }}
+      {...props}
+    >
+      {!!startIcon && <Icon marginRight="small">{startIcon}</Icon>}
+      {children}
+    </Flex>
+  )
+})
 
 export default SubTab

--- a/src/components/Tab.tsx
+++ b/src/components/Tab.tsx
@@ -36,10 +36,9 @@ ref: Ref<any>) {
       borderRight={
         vertical ? `1px solid ${active ? 'border-primary' : 'border'}` : null
       }
-      zIndex={theme.zIndexes.base + 0}
       _focusVisible={{
-        outline: '1px solid border-outline-focused',
         zIndex: theme.zIndexes.base + 1,
+        ...theme.partials.focus.default,
       }}
       {...props}
     >

--- a/src/components/TabList.tsx
+++ b/src/components/TabList.tsx
@@ -13,6 +13,10 @@ import {
   useRef,
 } from 'react'
 
+import theme from 'honorable-theme-default'
+
+import { useTheme } from 'styled-components'
+
 import Tab from './Tab'
 import SubTab from './SubTab'
 
@@ -100,6 +104,7 @@ function TabRenderer({
 }: TabRendererProps) {
   const ref = useRef(null)
   const { tabProps: props } = useTab({ key: item.key }, state, ref)
+  const theme = useTheme()
 
   const TabComponent = tabStyle === 'subtab' ? SubTab : Tab
 
@@ -120,7 +125,11 @@ function TabRenderer({
     return item.props.renderer({
       ...{
         cursor: 'pointer',
-        _focusVisible: { outline: '1px solid border-outline-focused' },
+        _focusVisible: { ...theme.partials.focus.default },
+        position: 'relative',
+        '&:focus, &:focus-visible': {
+          zIndex: theme.zIndexes.base + 1,
+        },
       },
       ...props,
     },
@@ -134,6 +143,12 @@ function TabRenderer({
       {...props}
       active={state.selectedKey === item.key}
       vertical={stateProps.orientation === 'vertical'}
+      position="relative"
+      {...{
+        '&:focus, &:focus-visible': {
+          zIndex: theme.zIndexes.base + 1,
+        },
+      }}
       {...item.props}
     >
       {item.rendered}

--- a/src/components/TabList.tsx
+++ b/src/components/TabList.tsx
@@ -13,8 +13,6 @@ import {
   useRef,
 } from 'react'
 
-import theme from 'honorable-theme-default'
-
 import { useTheme } from 'styled-components'
 
 import Tab from './Tab'


### PR DESCRIPTION
Changes to ensure consistent focus styling on tabs and make sure focus outline doesn’t get cropped off by adjacent tabs.