### PR TITLE
Tab List improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pluralsh-design-system",
-  "version": "1.160.0",
+  "version": "1.161.0",
   "description": "Pluralsh Design System",
   "main": "dist/index.js",
   "files": [

--- a/src/components/ListBox.tsx
+++ b/src/components/ListBox.tsx
@@ -77,12 +77,12 @@ const ScrollContainer = styled.div<ScrollContainerProps>(({ theme, extendStyle }
 }))
 
 function useItemWrappedChildren(children: ReactElement | ReactElement[],
-  header: ReactElement,
-  footer: ReactElement) {
+  header?: ReactElement,
+  footer?: ReactElement) {
   return useMemo(() => {
     // Children.map() prefixes the key props in an undocumented and possibly
     // unstable way, so using Children.forEach() to maintain original key values
-    const wrapped: JSX.Element[] = []
+    const wrapped: (JSX.Element)[] = []
 
     if (header) {
       wrapped.push(<Item key={HEADER_KEY}>{header}</Item>)

--- a/src/components/SubTab.tsx
+++ b/src/components/SubTab.tsx
@@ -1,5 +1,6 @@
 import { ReactNode, Ref, forwardRef } from 'react'
 import { DivProps, Flex, Icon } from 'honorable'
+import { useTheme } from 'styled-components'
 
 type SubTabProps = DivProps & {
   active?: boolean
@@ -9,30 +10,36 @@ type SubTabProps = DivProps & {
 
 const SubTab = forwardRef(({
   startIcon, active, children, ...props
-}: SubTabProps,
-ref: Ref<any>) => (
-  <Flex
-    ref={ref}
-    buttonMedium
-    tabIndex={0}
-    userSelect="none"
-    cursor="pointer"
-    textAlign="center"
-    paddingVertical="xsmall"
-    paddingHorizontal="medium"
-    borderRadius="medium"
-    color={active ? 'text' : 'text-xlight'}
-    backgroundColor={active ? 'fill-zero-selected' : 'none'}
-    _hover={{
-      color: 'text',
-      backgroundColor: active ? 'fill-zero-selected' : 'action-input-hover',
-    }}
-    _focusVisible={{ outline: '1px solid border-outline-focused' }}
-    {...props}
-  >
-    {!!startIcon && <Icon marginRight="small">{startIcon}</Icon>}
-    {children}
-  </Flex>
-))
+}: SubTabProps, ref: Ref<any>) => {
+  const theme = useTheme()
+
+  return (
+    <Flex
+      ref={ref}
+      buttonMedium
+      tabIndex={0}
+      userSelect="none"
+      cursor="pointer"
+      textAlign="center"
+      paddingVertical="xsmall"
+      paddingHorizontal="medium"
+      borderRadius="medium"
+      color={active ? 'text' : 'text-xlight'}
+      backgroundColor={active ? 'fill-zero-selected' : 'none'}
+      _hover={{
+        color: 'text',
+        backgroundColor: active ? 'fill-zero-selected' : 'action-input-hover',
+      }}
+      _focusVisible={{
+        ...theme.partials.focus.default,
+        zIndex: theme.zIndexes.base + 1,
+      }}
+      {...props}
+    >
+      {!!startIcon && <Icon marginRight="small">{startIcon}</Icon>}
+      {children}
+    </Flex>
+  )
+})
 
 export default SubTab

--- a/src/components/SubTab.tsx
+++ b/src/components/SubTab.tsx
@@ -2,10 +2,10 @@ import { ReactNode, Ref, forwardRef } from 'react'
 import { DivProps, Flex, Icon } from 'honorable'
 import { useTheme } from 'styled-components'
 
-type SubTabProps = DivProps & {
-  active?: boolean
+import { TabBaseProps } from './TabList'
+
+type SubTabProps = TabBaseProps & DivProps & {
   startIcon?: ReactNode
-  vertical?: boolean
 }
 
 const SubTab = forwardRef(({

--- a/src/components/Tab.tsx
+++ b/src/components/Tab.tsx
@@ -2,24 +2,22 @@ import { ReactNode, Ref, forwardRef } from 'react'
 import {
   Div, DivProps, Flex, Icon,
 } from 'honorable'
-import PropTypes from 'prop-types'
 import { useTheme } from 'styled-components'
 
-type TagProps = DivProps & {
-  active?: boolean
-  startIcon?: ReactNode
-  vertical?: boolean
-}
+import { TabBaseProps } from './TabList'
 
-const propTypes = {
-  active: PropTypes.bool,
-  startIcon: PropTypes.node,
-  vertical: PropTypes.bool,
+type TabProps = DivProps & TabBaseProps & {
+  startIcon?: ReactNode
 }
 
 function TabRef({
-  startIcon, active, children, vertical, ...props
-}: TagProps,
+  startIcon,
+  active,
+  children,
+  vertical,
+  textValue: _textValue,
+  ...props
+}: TabProps,
 ref: Ref<any>) {
   const theme = useTheme()
 
@@ -71,8 +69,7 @@ ref: Ref<any>) {
   )
 }
 
-TabRef.propTypes = propTypes
-
 const Tab = forwardRef(TabRef)
 
 export default Tab
+export { TabProps }

--- a/src/components/Tab.tsx
+++ b/src/components/Tab.tsx
@@ -36,10 +36,9 @@ ref: Ref<any>) {
       borderRight={
         vertical ? `1px solid ${active ? 'border-primary' : 'border'}` : null
       }
-      zIndex={theme.zIndexes.base + 0}
       _focusVisible={{
-        outline: '1px solid border-outline-focused',
         zIndex: theme.zIndexes.base + 1,
+        ...theme.partials.focus.default,
       }}
       {...props}
     >

--- a/src/components/TabList.tsx
+++ b/src/components/TabList.tsx
@@ -13,6 +13,10 @@ import {
   useRef,
 } from 'react'
 
+import theme from 'honorable-theme-default'
+
+import { useTheme } from 'styled-components'
+
 import Tab from './Tab'
 import SubTab from './SubTab'
 
@@ -100,6 +104,7 @@ function TabRenderer({
 }: TabRendererProps) {
   const ref = useRef(null)
   const { tabProps: props } = useTab({ key: item.key }, state, ref)
+  const theme = useTheme()
 
   const TabComponent = tabStyle === 'subtab' ? SubTab : Tab
 
@@ -120,7 +125,11 @@ function TabRenderer({
     return item.props.renderer({
       ...{
         cursor: 'pointer',
-        _focusVisible: { outline: '1px solid border-outline-focused' },
+        _focusVisible: { ...theme.partials.focus.default },
+        position: 'relative',
+        '&:focus, &:focus-visible': {
+          zIndex: theme.zIndexes.base + 1,
+        },
       },
       ...props,
     },
@@ -134,6 +143,12 @@ function TabRenderer({
       {...props}
       active={state.selectedKey === item.key}
       vertical={stateProps.orientation === 'vertical'}
+      position="relative"
+      {...{
+        '&:focus, &:focus-visible': {
+          zIndex: theme.zIndexes.base + 1,
+        },
+      }}
       {...item.props}
     >
       {item.rendered}

--- a/src/components/TabList.tsx
+++ b/src/components/TabList.tsx
@@ -2,71 +2,89 @@ import {
   Div, DivProps, Flex, FlexProps,
 } from 'honorable'
 import { AriaTabListProps } from '@react-types/tabs'
-import { Item } from '@react-stately/collections'
 import { useTab, useTabList, useTabPanel } from '@react-aria/tabs'
-import { TabListState } from '@react-stately/tabs'
-import { ItemProps, Node } from '@react-types/shared'
+import { TabListState, useTabListState } from '@react-stately/tabs'
+import { Node } from '@react-types/shared'
 import {
-  ComponentPropsWithRef,
+  Children,
   HTMLAttributes,
+  Key,
+  MutableRefObject,
+  ReactElement,
+  ReactNode,
   RefObject,
+  cloneElement,
+  useImperativeHandle,
+  useMemo,
   useRef,
 } from 'react'
+import styled, { useTheme } from 'styled-components'
 
-import { useTheme } from 'styled-components'
-
-import Tab from './Tab'
-import SubTab from './SubTab'
-
-type TabListStateProps = AriaTabListProps<object>;
+import { useItemWrappedChildren } from './ListBox'
 
 type Renderer = (
   props: HTMLAttributes<HTMLElement>,
-  ref: RefObject<any>,
+  ref: RefObject<any> | null | undefined,
+  state: TabListState<object> | null | undefined
+) => JSX.Element
+
+type TabBaseProps = {
+  key?: Key
+  ref?: MutableRefObject<any>
+  active?: boolean
+  vertical?: boolean
+  textValue?: string
+  renderer?: Renderer
+  children?: ReactNode
+}
+
+type TabListStateProps = Omit<AriaTabListProps<object>, 'children'>
+type TabStateRef = MutableRefObject<{
   state: TabListState<object>
-) => JSX.Element;
+  stateProps: AriaTabListProps<object>
+}>
 
-type MakeOptional<Type, Key extends keyof Type> = Omit<Type, Key> &
-  Partial<Pick<Type, Key>>;
-
-type TabListItemProps = ComponentPropsWithRef<typeof Tab> &
-  MakeOptional<ItemProps<void>, 'children'> & {
-    renderer?: Renderer;
-  };
-
-const TabListItem = Item as (props: TabListItemProps) => JSX.Element
-
-type TabStyle = 'default' | 'subtab';
+type ChildrenType = ReactElement<TabBaseProps> | ReactElement<TabBaseProps>[]
 
 type TabListProps = {
-  state: TabListState<object>;
-  stateProps: TabListStateProps;
-  renderer?: Renderer;
-  tabStyle?: TabStyle;
-};
+  stateRef: TabStateRef
+  renderer?: Renderer
+  children?: ChildrenType
+}
 function TabList({
-  state,
+  stateRef,
   stateProps,
   renderer,
-  tabStyle,
   ...props
 }: TabListProps & FlexProps) {
-  stateProps = {
+  const wrappedChildren = useItemWrappedChildren(props.children)
+  const finalStateProps: AriaTabListProps<object> = useMemo(() => ({
     ...{
       keyboardActivation: 'manual',
       orientation: 'horizontal',
+      children: [...wrappedChildren],
     },
     ...stateProps,
-  }
+  }),
+  [stateProps, wrappedChildren])
+
+  const state = useTabListState(finalStateProps)
+
+  useImperativeHandle(stateRef,
+    () => ({
+      state,
+      stateProps: finalStateProps,
+    }),
+    [state, finalStateProps])
+
   const ref = useRef<HTMLDivElement>(null)
-  const { tabListProps } = useTabList(stateProps, state, ref)
+  const { tabListProps } = useTabList(finalStateProps, state, ref)
   const tabChildren = [...state.collection].map(item => (
     <TabRenderer
       key={item.key}
       item={item}
       state={state}
-      stateProps={stateProps}
-      tabStyle={tabStyle}
+      stateProps={finalStateProps}
     />
   ))
 
@@ -91,35 +109,39 @@ function TabList({
   )
 }
 
+const TabClone = styled(({
+  className, children, tabRef, ...props
+}) => cloneElement(Children.only(children), {
+  className: `${children.props.className} ${className}`.trim(),
+  ref: tabRef,
+  ...props,
+}))<{ vertical: boolean }>(({ theme, vertical }) => ({
+  position: 'relative',
+  '&:focus, &:focus-visible': {
+    outline: 'none',
+    zIndex: theme.zIndexes.base + 1,
+  },
+  '&:focus-visible': {
+    ...theme.partials.focus.default,
+  },
+  ...(vertical
+    ? {
+      width: '100%',
+    }
+    : {}),
+}))
+
 type TabRendererProps = {
-  item: Node<unknown>;
-  state: TabListState<object>;
-  stateProps: TabListStateProps;
-  tabStyle: TabStyle;
-};
-function TabRenderer({
-  item, state, stateProps, tabStyle = 'default',
-}: TabRendererProps) {
+  item: Node<unknown>
+  state: TabListState<object>
+  stateProps: AriaTabListProps<object>
+}
+function TabRenderer({ item, state, stateProps }: TabRendererProps) {
   const ref = useRef(null)
   const { tabProps: props } = useTab({ key: item.key }, state, ref)
   const theme = useTheme()
 
-  const TabComponent = tabStyle === 'subtab' ? SubTab : Tab
-
   if (item.props.renderer) {
-    if (item.rendered) {
-      props.children = (
-        <TabComponent
-          active={state.selectedKey === item.key}
-          vertical={stateProps.orientation === 'vertical'}
-          width={stateProps.orientation === 'vertical' ? '100%' : 'auto'}
-          {...item.props}
-        >
-          {item.rendered}
-        </TabComponent>
-      )
-    }
-
     return item.props.renderer({
       ...{
         cursor: 'pointer',
@@ -136,36 +158,30 @@ function TabRenderer({
   }
 
   return (
-    <TabComponent
-      ref={ref}
+    <TabClone
+      tabRef={ref}
       {...props}
       active={state.selectedKey === item.key}
       vertical={stateProps.orientation === 'vertical'}
-      position="relative"
-      {...{
-        '&:focus, &:focus-visible': {
-          zIndex: theme.zIndexes.base + 1,
-        },
-      }}
       {...item.props}
     >
       {item.rendered}
-    </TabComponent>
+    </TabClone>
   )
 }
 
-type TabPanelProps = {
-  state: TabListState<object>;
-  stateProps: TabListStateProps;
-  renderer?: Renderer;
-};
+type TabPanelProps = DivProps & {
+  stateRef: TabStateRef
+  renderer?: Renderer
+}
 
-function TabPanel({
-  state,
-  stateProps,
+function WrappedTabPanel({
+  stateRef: {
+    current: { state, stateProps },
+  },
   renderer,
   ...props
-}: TabPanelProps & DivProps) {
+}: TabPanelProps) {
   const ref = useRef()
   const { tabPanelProps } = useTabPanel(stateProps, state, ref)
 
@@ -175,19 +191,30 @@ function TabPanel({
 
   return (
     <Div
+      ref={ref}
       {...tabPanelProps}
       {...props}
-      ref={ref}
     />
   )
+}
+
+function TabPanel(props: TabPanelProps) {
+  if (props.stateRef.current) {
+    return <WrappedTabPanel {...props} />
+  }
+
+  if (props.renderer) {
+    return props.renderer({ ...props }, null, null)
+  }
+
+  return <Div {...props} />
 }
 
 export {
   TabList,
   TabListProps,
-  TabListItem,
-  TabListItemProps,
   TabPanel,
   TabPanelProps,
   TabListStateProps,
+  TabBaseProps,
 }

--- a/src/components/TabList.tsx
+++ b/src/components/TabList.tsx
@@ -13,8 +13,6 @@ import {
   useRef,
 } from 'react'
 
-import theme from 'honorable-theme-default'
-
 import { useTheme } from 'styled-components'
 
 import Tab from './Tab'

--- a/src/index.ts
+++ b/src/index.ts
@@ -150,9 +150,9 @@ export { default as SubTab } from './components/SubTab'
 export { default as Tab } from './components/Tab'
 export {
   TabList,
-  TabListItem,
   TabListStateProps,
   TabPanel,
+  TabBaseProps,
 } from './components/TabList'
 export { default as TipCarousel } from './components/TipCarousel'
 export { default as Token } from './components/Token'

--- a/src/stories/TabList.stories.tsx
+++ b/src/stories/TabList.stories.tsx
@@ -1,15 +1,19 @@
 import {
   Button, Div, Flex, H1,
 } from 'honorable'
-import { Key, useState } from 'react'
-import { useTabListState } from '@react-stately/tabs'
+import {
+  Key, forwardRef, useRef, useState,
+} from 'react'
+import styled, { useTheme } from 'styled-components'
 
 import {
+  SubTab,
+  Tab,
+  TabBaseProps,
   TabList,
-  TabListItem,
   TabListStateProps,
   TabPanel,
-} from '../components/TabList'
+} from '../index'
 
 export default {
   title: 'Tab List',
@@ -43,50 +47,55 @@ const tabs = {
   },
 }
 
-function TemplateVertical() {
-  const orientation = 'vertical'
+function TemplateBasic(args: any) {
+  const tabStateRef = useRef()
+  const [selectedKey, setSelectedKey] = useState<Key>('1')
+  const orientation = args.orientation || 'horizontal'
   const tabListStateProps: TabListStateProps = {
     keyboardActivation: 'manual',
     orientation,
-    children: Object.entries(tabs).map(([key, tab]) => (
-      <TabListItem
-        key={key}
-        width={orientation === 'vertical' ? '100%' : 'auto'}
-      >
-        {tab.label}
-      </TabListItem>
-    )),
+    selectedKey,
+    onSelectionChange: setSelectedKey,
   }
-
-  const tabState = useTabListState(tabListStateProps)
 
   return (
     <Div>
-      <Flex flexDirection={orientation === 'vertical' ? 'row' : 'column'}>
+      <Flex
+        flexDirection={orientation === 'vertical' ? 'row' : 'column'}
+        maxWidth={800}
+      >
         <TabList
-          state={tabState}
+          stateRef={tabStateRef}
           stateProps={tabListStateProps}
           flexShrink={0}
           marginRight={orientation === 'vertical' ? 'large' : 0}
           marginBottom={orientation === 'vertical' ? 0 : 'xlarge'}
           width={orientation === 'vertical' ? '100px' : '100%'}
-        />
+        >
+          {Object.entries(tabs).map(([key, tab]) => (
+            <Tab
+              key={key}
+              textValue={tab.label}
+            >
+              {tab.label}
+            </Tab>
+          ))}
+        </TabList>
         <Div>
           <H1
             title1
             marginBottom="medium"
           >
-            {tabs[tabState.selectedKey]?.label}
+            {tabs[selectedKey]?.label}
           </H1>
           <TabPanel
-            state={tabState}
-            stateProps={tabListStateProps}
+            stateRef={tabStateRef}
             paddingTop="large"
             paddingBottom="large"
             borderTop="1px solid border"
             borderBottom="1px solid border"
           >
-            {tabs[tabState.selectedKey]?.content}
+            {tabs[selectedKey]?.content}
           </TabPanel>
         </Div>
       </Flex>
@@ -94,169 +103,161 @@ function TemplateVertical() {
   )
 }
 
-function TemplateHorizontal() {
-  const orientation = 'horizontal'
-  const tabListProps: TabListStateProps = {
-    keyboardActivation: 'manual',
-    orientation,
-    children: Object.entries(tabs).map(([key, tab]) => (
-      <TabListItem
-        key={key}
-        width="auto"
-      >
-        {tab.label}
-      </TabListItem>
-    )),
-  }
-
-  const tabState = useTabListState(tabListProps)
+const CustomLinkWrappedTab = styled(forwardRef<HTMLAnchorElement, TabBaseProps>(({
+  vertical,
+  active,
+  children,
+  textValue: _textValue,
+  renderer: _renderer,
+  ...props
+},
+ref) => {
+  const theme = useTheme()
 
   return (
-    <Div>
-      <Flex flexDirection="column">
-        <TabList
-          state={tabState}
-          stateProps={tabListProps}
-          flexShrink={0}
-          marginRight={0}
-          marginBottom="xlarge"
-          width="100%"
-        />
-        <Div>
-          <H1
-            title1
-            marginBottom="medium"
-          >
-            {tabs[tabState.selectedKey]?.label}
-          </H1>
-          <TabPanel
-            state={tabState}
-            stateProps={tabListProps}
-            paddingTop="large"
-            paddingBottom="large"
-            borderTop="1px solid border"
-            borderBottom="1px solid border"
-          >
-            {tabs[tabState.selectedKey]?.content}
-          </TabPanel>
-        </Div>
-      </Flex>
-    </Div>
+    <a
+      ref={ref}
+      target="_blank"
+      rel="noreferrer"
+      {...props}
+    >
+      <Tab
+        vertical={vertical}
+        active={active}
+        color={active ? theme.colors['text-success'] : 'red'}
+      >
+        {children}
+      </Tab>
+    </a>
   )
-}
+}))(({ active, theme }) => ({
+  display: 'block',
+  backgroundColor: active
+    ? theme.colors['fill-one']
+    : theme.colors['fill-zero'],
+  textDecoration: 'none',
+}))
+
+const MyCustomTab2 = forwardRef<any, any>(({ selectedKey, ...props }, ref) => (
+  <Flex
+    justifyContent="center"
+    alignItems="center"
+    {...props}
+    ref={ref}
+    width="100%"
+    padding="20px"
+    textAlign="center"
+    border="1px solid border-fill-two"
+  >
+    <Div
+      subtitle2
+      padding="small"
+      background={
+        selectedKey === 'bears'
+          ? 'action-primary'
+          : selectedKey === 'tigers'
+            ? 'icon-error'
+            : 'fill-two'
+      }
+    >
+      Com&shy;plete&shy;ly custom bears
+    </Div>
+  </Flex>
+))
 
 function TemplateComplex() {
-  const [selectedTabKey, setSelectedTabKey] = useState<Key>('lions')
+  const tabStateRef = useRef()
+  const [selectedKey, setSelectedKey] = useState<Key>('1')
   const orientation = 'vertical'
   const tabListStateProps: TabListStateProps = {
     keyboardActivation: 'manual',
-    selectedKey: selectedTabKey,
-    onSelectionChange: key => {
-      setSelectedTabKey(key)
-    },
     orientation,
-    children: [
-      <TabListItem
-        width="100%"
-        key="lions"
-      >
-        Lions
-      </TabListItem>,
-      <TabListItem
-        key="tigers"
-        renderer={({ children, ...props }, ref) => (
-          <Div
-            {...props}
-            ref={ref}
-            width="100%"
-            border="2px solid border-error"
-          >
-            {children}
-          </Div>
-        )}
-      >
-        Wrapped tigers
-      </TabListItem>,
-      <TabListItem
-        key="bears"
-        renderer={({ ...props }, ref, tabState) => (
-          <Flex
-            justifyContent="center"
-            alignItems="center"
-            {...props}
-            ref={ref}
-            width="100%"
-            padding="20px"
-            textAlign="center"
-            border="1px solid border-fill-two"
-          >
-            <Div
-              subtitle2
-              padding="small"
-              background={
-                tabState?.selectedKey === 'bears'
-                  ? 'action-primary'
-                  : 'fill-two'
-              }
-            >
-              Com&shy;plete&shy;ly custom bears
-            </Div>
-          </Flex>
-        )}
-      />,
-    ],
+    selectedKey,
+    onSelectionChange: setSelectedKey,
   }
-
-  const tabState = useTabListState(tabListStateProps)
 
   return (
     <Div>
       <Flex flexDirection={orientation === 'vertical' ? 'row' : 'column'}>
         <TabList
-          state={tabState}
+          stateRef={tabStateRef}
           stateProps={tabListStateProps}
           flexShrink={0}
           marginRight={orientation === 'vertical' ? 'large' : 0}
           marginBottom={orientation === 'vertical' ? 0 : 'xlarge'}
           width={orientation === 'vertical' ? '200px' : '100%'}
-          renderer={(props, ref, tabState) => (
+          renderer={(props, ref) => (
             <Div
               ref={ref}
               {...props}
               padding="10px"
               border="1px solid"
               borderColor={
-                tabState.selectedKey === 'lions'
+                selectedKey === 'lions'
                   ? 'border.primary'
-                  : tabState.selectedKey === 'tigers'
+                  : selectedKey === 'tigers'
                     ? 'border-warning'
-                    : tabState.selectedKey === 'bears'
+                    : selectedKey === 'bears'
                       ? 'border-success'
                       : 'border-error'
               }
             />
           )}
-        />
+        >
+          <CustomLinkWrappedTab
+            key="lions"
+            textValue="Lions"
+          >
+            {'<a>Lions</a>'}
+          </CustomLinkWrappedTab>
+          <Tab
+            key="tigers"
+            textValue="Tigers"
+            renderer={({ children, ...props }, ref) => (
+              <Div
+                {...props}
+                ref={ref}
+                width="100%"
+                border="2px solid border-error"
+              >
+                {children}
+              </Div>
+            )}
+          >
+            Wrapped tigers
+          </Tab>
+          <MyCustomTab2
+            key="bears"
+            textValue="something"
+            selectedKey={selectedKey}
+          />
+          <CustomLinkWrappedTab
+            key="ohmy"
+            textValue="Oh my!"
+          >
+            {'<a>Oh my!</a>'}
+          </CustomLinkWrappedTab>
+        </TabList>
+
         <Div>
           <H1
             title1
             marginBottom="medium"
           >
-            {tabs[tabState.selectedKey]?.label}
+            {tabs[selectedKey]?.label}
           </H1>
           <TabPanel
-            state={tabState}
-            stateProps={tabListStateProps}
+            stateRef={tabStateRef}
             paddingTop="large"
             paddingBottom="large"
             borderTop="1px solid border"
             borderBottom="1px solid border"
-            renderer={(props, ref, tabState) => (
+            renderer={(props, ref) => (
               <Button
                 ref={ref}
                 {...props}
               >
-                {tabs[tabState.selectedKey]?.content}
+                {tabs[selectedKey]?.content}
               </Button>
             )}
           />
@@ -267,50 +268,51 @@ function TemplateComplex() {
 }
 
 function TemplateSubTabs() {
+  const tabStateRef = useRef()
+  const [selectedKey, setSelectedKey] = useState<Key>('1')
   const orientation = 'horizontal'
-  const tabListProps: TabListStateProps = {
+  const tabListStateProps: TabListStateProps = {
     keyboardActivation: 'manual',
     orientation,
-    children: Object.entries(tabs).map(([key, tab]) => (
-      <TabListItem
-        key={key}
-        width="auto"
-      >
-        {tab.label}
-      </TabListItem>
-    )),
+    selectedKey,
+    onSelectionChange: setSelectedKey,
   }
-
-  const tabState = useTabListState(tabListProps)
 
   return (
     <Div>
       <Flex flexDirection="column">
         <TabList
-          state={tabState}
-          stateProps={tabListProps}
+          stateRef={tabStateRef}
+          stateProps={tabListStateProps}
           flexShrink={0}
           marginRight={0}
           marginBottom="xlarge"
           width="100%"
-          tabStyle="subtab"
-        />
+        >
+          {Object.entries(tabs).map(([key, tab]) => (
+            <SubTab
+              key={key}
+              textValue={tab.label}
+            >
+              {tab.label}
+            </SubTab>
+          ))}
+        </TabList>
         <Div>
           <H1
             title1
             marginBottom="medium"
           >
-            {tabs[tabState.selectedKey]?.label}
+            {tabs[selectedKey]?.label}
           </H1>
           <TabPanel
-            state={tabState}
-            stateProps={tabListProps}
+            stateRef={tabStateRef}
             paddingTop="large"
             paddingBottom="large"
             borderTop="1px solid border"
             borderBottom="1px solid border"
           >
-            {tabs[tabState.selectedKey]?.content}
+            {tabs[selectedKey]?.content}
           </TabPanel>
         </Div>
       </Flex>
@@ -318,11 +320,13 @@ function TemplateSubTabs() {
   )
 }
 
-export const Default = TemplateHorizontal.bind({})
+export const Default = TemplateBasic.bind({})
 Default.args = {}
 
-export const Vertical = TemplateVertical.bind({})
-Vertical.args = {}
+export const Vertical = TemplateBasic.bind({})
+Vertical.args = {
+  orientation: 'vertical',
+}
 
 export const SubTabs = TemplateSubTabs.bind({})
 SubTabs.args = {}


### PR DESCRIPTION
After actually trying to use the `TabList` in the app, I realized it was too complicated. This should simplify things and bring usage more inline with the `Select` and `ComboBox` components. Also fix some issues with focus styles.

See the "Tab List" story for new usage examples. I'm happy to go through the app and update any existing Tab Lists if approved.