### PR TITLE
Prevent react warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pluralsh-design-system",
-  "version": "1.167.0",
+  "version": "1.168.0",
   "description": "Pluralsh Design System",
   "main": "dist/index.js",
   "files": [

--- a/src/components/ListBox.tsx
+++ b/src/components/ListBox.tsx
@@ -88,13 +88,15 @@ function useItemWrappedChildren(children: ReactElement | ReactElement[],
       wrapped.push(<Item key={HEADER_KEY}>{header}</Item>)
     }
     Children.forEach(children, child => {
+      const { textValue, ...childProps } = child?.props || {}
+
       if (child) {
         const item = (
           <Item
             key={child.key}
-            textValue={child?.props?.textValue || ''}
+            textValue={textValue || ''}
           >
-            {child}
+            {cloneElement(child, childProps)}
           </Item>
         )
 


### PR DESCRIPTION
Stops the following react warning when using ListBox, TabList, Select or ComboBox:

> Warning: React does not recognize the `textValue` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `textvalue` instead. If you accidentally passed it from a parent component, remove it from the DOM element.