### PR TITLE
Allow arbitary components to be used as TabPanel

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pluralsh-design-system",
-  "version": "1.168.0",
+  "version": "1.169.0",
   "description": "Pluralsh Design System",
   "main": "dist/index.js",
   "files": [

--- a/src/components/TabList.tsx
+++ b/src/components/TabList.tsx
@@ -49,12 +49,14 @@ type ChildrenType = ReactElement<TabBaseProps> | ReactElement<TabBaseProps>[]
 type TabListProps = {
   stateRef: TabStateRef
   renderer?: Renderer
+  as?: ReactElement
   children?: ChildrenType
 }
 function TabList({
   stateRef,
   stateProps,
   renderer,
+  as,
   ...props
 }: TabListProps & FlexProps) {
   const wrappedChildren = useItemWrappedChildren(props.children)
@@ -87,6 +89,15 @@ function TabList({
       stateProps={finalStateProps}
     />
   ))
+
+  if (as) {
+    return cloneElement(as, {
+      ...tabListProps,
+      ...as.props,
+      ...{ children: tabChildren },
+      ref,
+    })
+  }
 
   if (renderer) {
     return renderer({ ...props, ...tabListProps, ...{ children: tabChildren } },
@@ -188,7 +199,11 @@ function WrappedTabPanel({
   const { tabPanelProps } = useTabPanel(stateProps, state, ref)
 
   if (as) {
-    return cloneElement(as, { ...tabPanelProps, ...props, ...as.props })
+    return cloneElement(as, {
+      ...tabPanelProps,
+      ...as.props,
+      children: props.children,
+    })
   }
 
   if (renderer) {
@@ -204,13 +219,22 @@ function WrappedTabPanel({
   )
 }
 
-function TabPanel(props: TabPanelProps) {
-  if (props.stateRef.current) {
-    return <WrappedTabPanel {...props} />
+function TabPanel({
+  as, renderer, stateRef, ...props
+}: TabPanelProps) {
+  if (stateRef.current) {
+    return (
+      <WrappedTabPanel
+        as={as}
+        renderer={renderer}
+        stateRef={stateRef}
+        {...props}
+      />
+    )
   }
 
-  if (props.renderer) {
-    return props.renderer({ ...props }, null, null)
+  if (renderer) {
+    return renderer({ ...props }, null, null)
   }
 
   return <Div {...props} />

--- a/src/components/TabList.tsx
+++ b/src/components/TabList.tsx
@@ -173,6 +173,7 @@ function TabRenderer({ item, state, stateProps }: TabRendererProps) {
 type TabPanelProps = DivProps & {
   stateRef: TabStateRef
   renderer?: Renderer
+  as?: ReactElement
 }
 
 function WrappedTabPanel({
@@ -180,10 +181,15 @@ function WrappedTabPanel({
     current: { state, stateProps },
   },
   renderer,
+  as,
   ...props
 }: TabPanelProps) {
   const ref = useRef()
   const { tabPanelProps } = useTabPanel(stateProps, state, ref)
+
+  if (as) {
+    return cloneElement(as, { ...tabPanelProps, ...props, ...as.props })
+  }
 
   if (renderer) {
     return renderer({ ...tabPanelProps, ...props }, ref, state)

--- a/src/stories/TabList.stories.tsx
+++ b/src/stories/TabList.stories.tsx
@@ -252,15 +252,10 @@ function TemplateComplex() {
             paddingBottom="large"
             borderTop="1px solid border"
             borderBottom="1px solid border"
-            renderer={(props, ref) => (
-              <Button
-                ref={ref}
-                {...props}
-              >
-                {tabs[selectedKey]?.content}
-              </Button>
-            )}
-          />
+            as={<Button />}
+          >
+            {tabs[selectedKey]?.content}
+          </TabPanel>
         </Div>
       </Flex>
     </Div>

--- a/src/stories/TabList.stories.tsx
+++ b/src/stories/TabList.stories.tsx
@@ -182,14 +182,12 @@ function TemplateComplex() {
         <TabList
           stateRef={tabStateRef}
           stateProps={tabListStateProps}
-          flexShrink={0}
-          marginRight={orientation === 'vertical' ? 'large' : 0}
-          marginBottom={orientation === 'vertical' ? 0 : 'xlarge'}
-          width={orientation === 'vertical' ? '200px' : '100%'}
-          renderer={(props, ref) => (
+          as={(
             <Div
-              ref={ref}
-              {...props}
+              flexShrink={0}
+              marginRight={orientation === 'vertical' ? 'large' : 0}
+              marginBottom={orientation === 'vertical' ? 0 : 'xlarge'}
+              width={orientation === 'vertical' ? '200px' : '100%'}
               padding="10px"
               border="1px solid"
               borderColor={


### PR DESCRIPTION
Needed for instances where adding an extra <div> to the DOM for the Tab Panel will break the layout.