### PR TITLE
Remove max height restrictions from chips

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pluralsh-design-system",
-  "version": "1.168.0",
+  "version": "1.169.0",
   "description": "Pluralsh Design System",
   "main": "dist/index.js",
   "files": [

--- a/src/components/Chip.tsx
+++ b/src/components/Chip.tsx
@@ -46,12 +46,6 @@ const severityToColor = {
   critical: 'text-error',
 }
 
-const sizeToHeight: { [key in 'small' | 'medium' | 'large']: number } = {
-  small: 20,
-  medium: 24,
-  large: 32,
-}
-
 const sizeToCloseHeight: { [key in 'small' | 'medium' | 'large']: number } = {
   small: 8,
   medium: 10,
@@ -93,7 +87,6 @@ ref: Ref<any>) {
       paddingHorizontal={size === 'small' ? 'xsmall' : 'small'}
       alignItems="center"
       display="inline-flex"
-      maxHeight={sizeToHeight[size]}
       {...props}
     >
       {loading && (
@@ -116,7 +109,6 @@ ref: Ref<any>) {
         fontSize={size === 'small' ? 12 : 14}
         fontWeight={size === 'small' ? 400 : 600}
         lineHeight={size === 'small' ? '16px' : '20px'}
-        height={size === 'small' ? '16px' : '20px'}
         gap={4}
       >
         {children}
@@ -125,7 +117,6 @@ ref: Ref<any>) {
         <CloseIcon
           className="closeIcon"
           paddingLeft="xsmall"
-          // color="text-light"
           size={sizeToCloseHeight[size]}
           _hover={{ color: 'blue' }}
         />

--- a/src/stories/Chip.stories.tsx
+++ b/src/stories/Chip.stories.tsx
@@ -3,6 +3,7 @@ import { Flex, H1 } from 'honorable'
 import { StatusOkIcon } from '..'
 
 import Chip from '../components/Chip'
+import Card from '../components/Card'
 
 export default {
   title: 'Chip',
@@ -529,6 +530,51 @@ function Template(args: any) {
           Critical
         </Chip>
       </Flex>
+      {/* Wrapping */}
+      <H1
+        subtitle2
+        marginBottom="small"
+      >Wrapping
+      </H1>
+      <Card
+        align="center"
+        padding="medium"
+        width="100px"
+        gap="4px"
+        wrap="wrap"
+      >
+        <Chip
+          severity="neutral"
+          size="small"
+          {...args}
+        >
+          Physical
+        </Chip>
+        <Chip
+          severity="warning"
+          size="small"
+          marginTop="4px"
+          {...args}
+        >
+          Local
+        </Chip>
+        <Chip
+          severity="error"
+          size="small"
+          marginTop="4px"
+          {...args}
+        >
+          Adjacent Network
+        </Chip>
+        <Chip
+          severity="critical"
+          size="small"
+          marginTop="4px"
+          {...args}
+        >
+          Network
+        </Chip>
+      </Card>
     </>
   )
 }


### PR DESCRIPTION
<img width="125" alt="Zrzut ekranu 2022-08-23 o 10 20 01" src="https://user-images.githubusercontent.com/2823399/186109007-720c2379-2441-45e0-b855-223da0219918.png">

We don't need height limits as proper line heights and paddings allow to keep the sizes right. It's required to close [ENG-525](https://linear.app/pluralsh/issue/ENG-525/[vqa]-vulnerabilities). 

