### PR TITLE
Set chip width to min-content

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pluralsh-design-system",
-  "version": "1.169.0",
+  "version": "1.170.0",
   "description": "Pluralsh Design System",
   "main": "dist/index.js",
   "files": [

--- a/src/components/Chip.tsx
+++ b/src/components/Chip.tsx
@@ -110,6 +110,7 @@ ref: Ref<any>) {
         fontWeight={size === 'small' ? 400 : 600}
         lineHeight={size === 'small' ? '16px' : '20px'}
         gap={4}
+        width="min-content"
       >
         {children}
       </Flex>

--- a/src/stories/Chip.stories.tsx
+++ b/src/stories/Chip.stories.tsx
@@ -539,7 +539,7 @@ function Template(args: any) {
       <Card
         align="center"
         padding="medium"
-        width="100px"
+        width="140px"
         gap="4px"
         wrap="wrap"
       >


### PR DESCRIPTION
I have missed this in my previous change. It's needed so chip will not stretch to 100% when text wraps.