### PR TITLE
Fix TabPanel ‘as’ functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pluralsh-design-system",
-  "version": "1.172.0",
+  "version": "1.173.0",
   "description": "Pluralsh Design System",
   "main": "dist/index.js",
   "files": [


### PR DESCRIPTION
Using the ‘as’ property was breaking in certain circumstances. This should fix that. Needed for [ENG-534 - Set proper scrollable areas](https://linear.app/pluralsh/issue/ENG-534/set-proper-scrollable-areas)