### PR TITLE
Allow dynamic setting of initials in IconFrame

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pluralsh-design-system",
-  "version": "1.177.0",
+  "version": "1.179.0",
   "description": "Pluralsh Design System",
   "main": "dist/index.js",
   "files": [

--- a/src/components/IconFrame.tsx
+++ b/src/components/IconFrame.tsx
@@ -1,6 +1,10 @@
 import { DivProps, Flex, Img } from 'honorable'
 import PropTypes from 'prop-types'
 import { Ref, forwardRef } from 'react'
+import { CSSObject } from 'styled-components'
+import last from 'lodash/last'
+
+import { styledTheme as theme } from '../theme'
 
 type IconFrameProps = DivProps & {
   size?: 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | string
@@ -9,6 +13,8 @@ type IconFrameProps = DivProps & {
   clickable?: boolean
   url?: string
   alt?: string
+  name?: string
+  initials?: string
 }
 
 const propTypes = {
@@ -20,7 +26,9 @@ const propTypes = {
   alt: PropTypes.string,
 }
 
-const sizeToWidth: { [key in 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge']: number } = {
+const sizeToWidth: {
+  [key in 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge']: number
+} = {
   xsmall: 40,
   small: 64,
   medium: 96,
@@ -28,7 +36,9 @@ const sizeToWidth: { [key in 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge']
   xlarge: 160,
 }
 
-const sizeToIconWidth: { [key in 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge']: number } = {
+const sizeToIconWidth: {
+  [key in 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge']: number
+} = {
   xsmall: 24,
   small: 48,
   medium: 64,
@@ -42,10 +52,35 @@ const hueToColor: { [key in 'default' | 'lighter' | 'lightest']: string } = {
   lightest: 'fill-three',
 }
 
-const hueToBorderColor: { [key in 'default' | 'lighter' | 'lightest']: string } = {
+const hueToBorderColor: {
+  [key in 'default' | 'lighter' | 'lightest']: string
+} = {
   default: 'border',
   lighter: 'border-fill-two',
   lightest: 'border-input',
+}
+
+const sizeToFont: {
+  [key in 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge']: CSSObject
+} = {
+  xsmall: theme.partials.text.body2Bold,
+  small: theme.partials.text.subtitle2,
+  medium: theme.partials.text.subtitle1,
+  large: theme.partials.text.title2,
+  xlarge: theme.partials.text.title2,
+}
+
+export function toInitials(name: string) {
+  let initials = name
+    .trim()
+    .split(' ')
+    .map(n => n.charAt(0).toUpperCase())
+
+  if (initials.length > 2) {
+    initials = [initials[0], last(initials)]
+  }
+
+  return initials.join('')
 }
 
 function IconFrameRef({
@@ -55,19 +90,24 @@ function IconFrameRef({
   clickable = false,
   url,
   alt,
+  name,
+  initials,
   onClose,
   ...props
-}: IconFrameProps, ref: Ref<any>) {
+}: IconFrameProps,
+ref: Ref<any>) {
   const boxSize = sizeToWidth[size]
-  const iconSize = spacing === 'padding' ? sizeToIconWidth[size] : sizeToWidth[size] + 1
+  const iconSize
+    = spacing === 'padding' ? sizeToIconWidth[size] : sizeToWidth[size] + 1
   const color = hueToColor[hue]
   const borderColor = hueToBorderColor[hue]
+  const hasBorder = spacing === 'padding' && url
 
   return (
     <Flex
       backgroundColor={color}
       borderRadius="medium"
-      border={spacing === 'padding' ? '1px solid border' : 'none'}
+      border={hasBorder ? '1px solid border' : 'none'}
       borderColor={borderColor}
       width={boxSize}
       height={boxSize}
@@ -80,14 +120,29 @@ function IconFrameRef({
       _hover={clickable ? { backgroundColor: borderColor } : null}
       onClick={clickable ? onClose : null}
     >
-      <Img
-        ref={ref}
-        src={url}
-        alt={alt}
-        width={iconSize}
-        height={iconSize}
-        {...props}
-      />
+      {url ? (
+        <Img
+          ref={ref}
+          src={url}
+          alt={alt}
+          width={iconSize}
+          height={iconSize}
+          {...props}
+        />
+      ) : (
+        <Flex
+          width="100%"
+          height="100%"
+          alignItems="center"
+          justifyContent="center"
+          backgroundColor={theme.colors['action-primary']}
+          userSelect="none"
+          textTransform="uppercase"
+          {...sizeToFont[size]}
+        >
+          {initials || (name ? toInitials(name) : '')}
+        </Flex>
+      )}
     </Flex>
   )
 }

--- a/src/stories/IconFrame.stories.tsx
+++ b/src/stories/IconFrame.stories.tsx
@@ -7,7 +7,12 @@ export default {
   component: IconFrame,
   argTypes: {
     icon: {
-      options: ['/logos/plural-logomark-only-black.svg', '/logos/plural-logomark-only-white.svg', '/logos/airflow-logo.svg', '/logos/airbyte-logo.svg'],
+      options: [
+        '/logos/plural-logomark-only-black.svg',
+        '/logos/plural-logomark-only-white.svg',
+        '/logos/airflow-logo.svg',
+        '/logos/airbyte-logo.svg',
+      ],
       control: {
         type: 'select',
         labels: {
@@ -27,144 +32,57 @@ export default {
   },
 }
 
+const sizes = [
+  { label: 'Extra Large', size: 'xlarge' },
+  { label: 'Large', size: 'large' },
+  { label: 'Medium', size: 'medium' },
+  { label: 'Small', size: 'small' },
+  { label: 'Extra Small', size: 'xsmall' },
+]
+
 function Template(args: any) {
   return (
     <Flex
       gap={16}
       direction="column"
     >
-      <H3>Extra Large</H3>
-      <Flex
-        direction="row"
-        gap={16}
-      >
-        <IconFrame
-          size="xlarge"
-          url={args.icon}
-          {...args}
-        />
+      {sizes.map(({ label, size }) => (
+        <>
+          <H3>{label}</H3>
+          <Flex
+            direction="row"
+            gap={16}
+          >
+            <IconFrame
+              size={size}
+              url={args.icon}
+              {...args}
+            />
 
-        <IconFrame
-          size="xlarge"
-          url="photo.png"
-          spacing="none"
-          {...args}
-        />
+            <IconFrame
+              size={size}
+              url="photo.png"
+              spacing="none"
+              {...args}
+            />
 
-        <IconFrame
-          size="xlarge"
-          url="user.png"
-          spacing="none"
-          {...args}
-        />
-      </Flex>
-
-      <H3>Large</H3>
-      <Flex
-        direction="row"
-        gap={16}
-      >
-        <IconFrame
-          size="large"
-          url={args.icon}
-          {...args}
-        />
-
-        <IconFrame
-          size="large"
-          url="photo.png"
-          spacing="none"
-          {...args}
-        />
-
-        <IconFrame
-          size="large"
-          url="user.png"
-          spacing="none"
-          {...args}
-        />
-      </Flex>
-
-      <H3>Medium</H3>
-      <Flex
-        direction="row"
-        gap={16}
-      >
-        <IconFrame
-          url={args.icon}
-          {...args}
-        />
-
-        <IconFrame
-          url="photo.png"
-          spacing="none"
-          {...args}
-        />
-
-        <IconFrame
-          url="user.png"
-          spacing="none"
-          {...args}
-        />
-      </Flex>
-
-      <H3>Small</H3>
-      <Flex
-        direction="row"
-        gap={16}
-      >
-        <IconFrame
-          size="small"
-          url={args.icon}
-          {...args}
-        />
-
-        <IconFrame
-          size="small"
-          url="photo.png"
-          spacing="none"
-          {...args}
-        />
-
-        <IconFrame
-          size="small"
-          url="user.png"
-          spacing="none"
-          {...args}
-        />
-      </Flex>
-
-      <H3>Extra Small</H3>
-      <Flex
-        direction="row"
-        gap={16}
-      >
-        <IconFrame
-          size="xsmall"
-          url={args.icon}
-          {...args}
-        />
-
-        <IconFrame
-          size="xsmall"
-          url="photo.png"
-          spacing="none"
-          {...args}
-        />
-
-        <IconFrame
-          size="xsmall"
-          url="user.png"
-          spacing="none"
-          {...args}
-        />
-      </Flex>
+            <IconFrame
+              size={size}
+              name={args.name || undefined}
+              initials={args.name || undefined}
+              {...args}
+            />
+          </Flex>
+        </>
+      ))}
     </Flex>
   )
 }
 
 export const Default = Template.bind({})
 Default.args = {
+  name: 'Michael J Guarino',
+  initials: '',
   icon: '/logos/plural-logomark-only-black.svg',
   hue: 'default',
   clickable: false,

--- a/src/stories/PageCard.stories.tsx
+++ b/src/stories/PageCard.stories.tsx
@@ -51,6 +51,13 @@ function Template() {
         subheading="GCP"
       />
       <PageCard
+        icon={{
+          name: 'Jimmy J Unknown',
+        }}
+        heading="Jimmy J Unknown"
+      />
+
+      <PageCard
         heading="airflow-identity"
         icon={{
           url: '/logos/airflow-logo.svg',


### PR DESCRIPTION
This allows the dynamic setting of the initials in a blue `IconFrame`. If `initials` is specified, that string is used directly. Otherwise if `name` is provided, that will be automatically converted to initials. Needed for use in certain `PageCards`