### PR TITLE
Fix Layout/Styling issues on ContentCards

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pluralsh-design-system",
-  "version": "1.177.0",
+  "version": "1.180.0",
   "description": "Pluralsh Design System",
   "main": "dist/index.js",
   "files": [

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -1,6 +1,6 @@
 import { Div, DivProps } from 'honorable'
 import { forwardRef } from 'react'
-import { CSSObject } from 'styled-components'
+import { CSSObject } from '@emotion/styled'
 
 import { styledTheme as theme } from '../theme'
 
@@ -52,7 +52,7 @@ const cornerSizeToBorderRadius: {
 }
 
 const hueToScroll: {
-  [key in CardHue]: CSSObject
+  [key in CardHue]: Record<string, any>
 } = {
   default: theme.partials.scrollBar({ hue: 'default' }),
   lighter: theme.partials.scrollBar({ hue: 'lighter' }),
@@ -60,8 +60,13 @@ const hueToScroll: {
 }
 
 const Card = forwardRef<HTMLDivElement, CardProps>(({
-  cornerSize: size = 'large', hue = 'default', selected = false, clickable = false, ...props
-}, ref) => (
+  cornerSize: size = 'large',
+  hue = 'default',
+  selected = false,
+  clickable = false,
+  ...props
+},
+ref) => (
   <Div
     ref={ref}
     border={`1px solid ${hueToBorderColor[hue]}`}
@@ -70,7 +75,8 @@ const Card = forwardRef<HTMLDivElement, CardProps>(({
     {...(clickable && {
       cursor: 'pointer',
     })}
-    {...(clickable && !selected && {
+    {...(clickable
+        && !selected && {
       _hover: { backgroundColor: hueToHoverBGColor[hue] },
     })}
     {...hueToScroll[hue]}

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -1,6 +1,5 @@
 import { Div, DivProps } from 'honorable'
 import { forwardRef } from 'react'
-import { CSSObject } from '@emotion/styled'
 
 import { styledTheme as theme } from '../theme'
 

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -1,5 +1,8 @@
 import { Div, DivProps } from 'honorable'
 import { forwardRef } from 'react'
+import { CSSObject } from 'styled-components'
+
+import { styledTheme as theme } from '../theme'
 
 type CardSize = 'medium' | 'large' | string
 type CardHue = 'default' | 'lighter' | 'lightest' | string
@@ -48,6 +51,14 @@ const cornerSizeToBorderRadius: {
   large: 'large',
 }
 
+const hueToScroll: {
+  [key in CardHue]: CSSObject
+} = {
+  default: theme.partials.scrollBar({ hue: 'default' }),
+  lighter: theme.partials.scrollBar({ hue: 'lighter' }),
+  lightest: theme.partials.scrollBar({ hue: 'lighter' }),
+}
+
 const Card = forwardRef<HTMLDivElement, CardProps>(({
   cornerSize: size = 'large', hue = 'default', selected = false, clickable = false, ...props
 }, ref) => (
@@ -62,6 +73,7 @@ const Card = forwardRef<HTMLDivElement, CardProps>(({
     {...(clickable && !selected && {
       _hover: { backgroundColor: hueToHoverBGColor[hue] },
     })}
+    {...hueToScroll[hue]}
     {...props}
   />
 ))

--- a/src/components/ContentCard.tsx
+++ b/src/components/ContentCard.tsx
@@ -14,13 +14,15 @@ const ContentCard = forwardRef<HTMLDivElement, ContentCardProps>(({
 }, ref) => (
   <Card
     ref={ref}
-    as={Flex}
-    justifyContent="center"
-    padding="xlarge"
+    overflowY="auto"
+    paddingHorizontal="xlarge"
     {...props}
   >
     <Div
       width="100%"
+      marginLeft="auto"
+      marginRight="auto"
+      paddingVertical="xlarge"
       maxWidth={608}
       {...innerProps}
     >

--- a/src/components/ContentCard.tsx
+++ b/src/components/ContentCard.tsx
@@ -1,4 +1,4 @@
-import { Div, DivProps, Flex } from 'honorable'
+import { Div, DivProps } from 'honorable'
 import { forwardRef } from 'react'
 
 import { Card } from '../index'

--- a/src/stories/ContentCard.stories.tsx
+++ b/src/stories/ContentCard.stories.tsx
@@ -1,5 +1,5 @@
 import {
-  Div, H1, P,
+  Div, H1, H2, P,
 } from 'honorable'
 
 import { ContentCard } from '../index'
@@ -9,11 +9,50 @@ export default {
   component: null,
 }
 
+const content = (
+  <>
+    <p>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+      tempor incididunt ut labore et dolore magna aliqua. Nunc eget lorem dolor
+      sed viverra ipsum nunc aliquet bibendum. Ultrices dui sapien eget mi proin
+      sed libero enim sed. Fames ac turpis egestas maecenas pharetra. Orci eu
+      lobortis elementum nibh tellus molestie nunc non blandit. Curabitur vitae
+      nunc sed velit dignissim sodales. Nec feugiat in fermentum posuere. Et leo
+      duis ut diam quam. Amet nulla facilisi morbi tempus iaculis urna id
+      volutpat. In ornare quam viverra orci. Nec feugiat nisl pretium fusce id
+      velit. Purus viverra accumsan in nisl nisi scelerisque. Massa sed
+      elementum tempus egestas sed. Netus et malesuada fames ac turpis egestas
+      sed tempus.
+    </p>
+    <p>
+      Integer malesuada nunc vel risus commodo. Feugiat in ante metus dictum at
+      tempor commodo. Mi quis hendrerit dolor magna eget est lorem ipsum.
+      Sagittis purus sit amet volutpat consequat mauris nunc congue. Quisque id
+      diam vel quam elementum pulvinar etiam. Tellus elementum sagittis vitae et
+      leo duis ut diam. A erat nam at lectus urna duis. Amet consectetur
+      adipiscing elit duis tristique sollicitudin nibh sit. Senectus et netus et
+      malesuada fames ac. Vitae proin sagittis nisl rhoncus mattis rhoncus.
+      Semper viverra nam libero justo laoreet sit amet cursus sit. Mauris nunc
+      congue nisi vitae suscipit tellus mauris a diam. Aenean sed adipiscing
+      diam donec adipiscing tristique. Pharetra vel turpis nunc eget lorem
+      dolor. Nec dui nunc mattis enim ut. Elementum nibh tellus molestie nunc
+      non blandit. At urna condimentum mattis pellentesque id. Sagittis id
+      consectetur purus ut faucibus pulvinar. Quis imperdiet massa tincidunt
+      nunc pulvinar sapien et ligula ullamcorper.
+    </p>
+  </>
+)
+
+const cards = [{ hue: 'default' }, { hue: 'lighter' }, { hue: 'lightest' }]
+
 function Template() {
-  return (
-    <>
+  return cards.map(({ hue }) => (
+    <Div>
+      <H1 caption>hue="{hue}"</H1>
       <ContentCard
+        hue={hue}
         marginBottom="xxlarge"
+        maxHeight="250px"
       >
         <Div
           alignItems="center"
@@ -22,42 +61,13 @@ function Template() {
           width="100%"
           padding="0"
         >
-          <H1 subtitle2>Content Area</H1>
+          <H2 subtitle2>Content Area</H2>
           <P caption>(hue="default")</P>
+          <P>{content}</P>
         </Div>
       </ContentCard>
-      <ContentCard
-        hue="lighter"
-        marginBottom="xxlarge"
-      >
-        <Div
-          alignItems="center"
-          justifyContent="center"
-          border="1px solid rgba(255,255,255, 0.05)"
-          width="100%"
-          padding="0"
-        >
-          <H1 subtitle2>Content Area</H1>
-          <P caption>(hue="lighter")</P>
-        </Div>
-      </ContentCard>
-      <ContentCard
-        hue="lightest"
-        marginBottom="xxlarge"
-      >
-        <Div
-          alignItems="center"
-          justifyContent="center"
-          border="1px solid rgba(255,255,255, 0.05)"
-          width="100%"
-          padding="0"
-        >
-          <H1 subtitle2>Content Area</H1>
-          <P caption>(hue="lightest")</P>
-        </Div>
-      </ContentCard>
-    </>
-  )
+    </Div>
+  ))
 }
 
 export const Default = Template.bind({})


### PR DESCRIPTION
Bottom padding was getting ignored for `ContentCards` with scrolling content due to flexbox weirdness. This fixes that as well as creates appropriate scrollbar coloring for all `Card` hues.