### PR TITLE
Update Codeline to accept `displayText` prop

### DIFF
--- a/src/components/Codeline.tsx
+++ b/src/components/Codeline.tsx
@@ -7,11 +7,13 @@ import Tooltip from '../components/Tooltip'
 
 import CopyIcon from './icons/CopyIcon'
 
-type CodelineProps = FlexProps
+type CodelineProps = FlexProps & {
+  displayText?: string
+}
 
 const propTypes = {}
 
-function CodelineRef({ children, ...props }: CodelineProps, ref: Ref<any>) {
+function CodelineRef({ children, displayText, ...props }: CodelineProps, ref: Ref<any>) {
   const [copied, setCopied] = useState(false)
 
   useEffect(() => {
@@ -48,7 +50,7 @@ function CodelineRef({ children, ...props }: CodelineProps, ref: Ref<any>) {
           textOverflow="ellipsis"
           overflow="hidden"
         >
-          {children}
+          {displayText || children}
         </Div>
       </Flex>
       <Flex

--- a/src/stories/Codeline.stories.tsx
+++ b/src/stories/Codeline.stories.tsx
@@ -15,10 +15,13 @@ function Template(args: any) {
     >
       <Codeline {...args} />
       <Codeline
+        displayText="••••••••••"
+        {...args}
+      />
+      <Codeline
         {...args}
         maxWidth="200px"
       />
-
     </Flex>
   )
 }


### PR DESCRIPTION
To allow for secrets strings.

<img width="1399" alt="image" src="https://user-images.githubusercontent.com/4154003/186677771-b0e87d34-7a07-4e41-af1c-73f7390cf551.png">
