### PR TITLE
Add prepublishOnly build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "build": "npx tsc --declaration",
     "clean": "rimraf storybook-static dist",
     "lint": "eslint src --ext ts,tsx,js,jsx",
-    "fix": "eslint src --ext ts,tsx,js,jsx --fix"
+    "fix": "eslint src --ext ts,tsx,js,jsx --fix",
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "@floating-ui/react-dom-interactions": "0.8.1",


### PR DESCRIPTION
The other day I forgot to run `npm run build` before publishing the package, resulted in an empty project.
This ensures that the build script is ran before publishing.