### PR TITLE
Fix name of App Icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pluralsh-design-system",
-  "version": "1.186.0",
+  "version": "1.187.0",
   "description": "Pluralsh Design System",
   "main": "dist/index.js",
   "files": [

--- a/src/components/AppIcon.tsx
+++ b/src/components/AppIcon.tsx
@@ -6,7 +6,7 @@ import last from 'lodash/last'
 
 import { styledTheme as theme } from '../theme'
 
-type IconFrameProps = DivProps & {
+type AppIconProps = DivProps & {
   size?: 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | string
   spacing?: 'none' | 'padding' | string
   hue?: 'default' | 'lighter' | 'lightest' | string
@@ -83,7 +83,7 @@ export function toInitials(name: string) {
   return initials.join('')
 }
 
-function IconFrameRef({
+function AppIconRef({
   size = 'medium',
   spacing = 'padding',
   hue = 'lighter',
@@ -94,7 +94,7 @@ function IconFrameRef({
   initials,
   onClose,
   ...props
-}: IconFrameProps,
+}: AppIconProps,
 ref: Ref<any>) {
   const boxSize = sizeToWidth[size]
   const iconSize
@@ -147,9 +147,9 @@ ref: Ref<any>) {
   )
 }
 
-const IconFrame = forwardRef(IconFrameRef)
+const AppIcon = forwardRef(AppIconRef)
 
-IconFrame.propTypes = propTypes
+AppIcon.propTypes = propTypes
 
-export default IconFrame
-export { IconFrameProps }
+export default AppIcon
+export { AppIconProps }

--- a/src/components/PageCard.tsx
+++ b/src/components/PageCard.tsx
@@ -3,10 +3,10 @@ import {
 } from 'honorable'
 import { ReactNode, forwardRef } from 'react'
 
-import IconFrame, { IconFrameProps } from './IconFrame'
+import AppIcon, { AppIconProps } from './AppIcon'
 
 type PageCardProps = {
-  icon: Omit<IconFrameProps, 'size'>
+  icon: Omit<AppIconProps, 'size'>
   heading?: ReactNode
   subheading?: ReactNode
   subheadingIcon?: ReactNode
@@ -30,7 +30,7 @@ ref) => (
       alignItems="center"
       {...props}
     >
-      <IconFrame
+      <AppIcon
         size="small"
         hue="default"
         {...icon}

--- a/src/index.ts
+++ b/src/index.ts
@@ -138,7 +138,7 @@ export { default as PageCard, PageCardProps } from './components/PageCard'
 export { default as PageTitle } from './components/PageTitle'
 export { default as ProgressBar } from './components/ProgressBar'
 export { default as Radio } from './components/Radio'
-export { default as IconFrame } from './components/IconFrame'
+export { default as AppIcon } from './components/AppIcon'
 export { default as RepositoryCard } from './components/RepositoryCard'
 export { default as Stepper } from './components/Stepper'
 export {

--- a/src/stories/AppIcon.stories.tsx
+++ b/src/stories/AppIcon.stories.tsx
@@ -1,10 +1,10 @@
 import { Flex, H3 } from 'honorable'
 
-import IconFrame from '../components/IconFrame'
+import AppIcon from '../components/AppIcon'
 
 export default {
-  title: 'IconFrame',
-  component: IconFrame,
+  title: 'AppIcon',
+  component: AppIcon,
   argTypes: {
     icon: {
       options: [
@@ -53,20 +53,20 @@ function Template(args: any) {
             direction="row"
             gap={16}
           >
-            <IconFrame
+            <AppIcon
               size={size}
               url={args.icon}
               {...args}
             />
 
-            <IconFrame
+            <AppIcon
               size={size}
               url="photo.png"
               spacing="none"
               {...args}
             />
 
-            <IconFrame
+            <AppIcon
               size={size}
               name={args.name || undefined}
               initials={args.name || undefined}

--- a/src/stories/ComboBox.stories.tsx
+++ b/src/stories/ComboBox.stories.tsx
@@ -6,9 +6,9 @@ import styled from 'styled-components'
 import Fuse from 'fuse.js'
 
 import {
+  AppIcon,
   Chip,
   ComboBox,
-  IconFrame,
   ListBoxFooterPlus,
   ListBoxItem,
   ListBoxItemChipList,
@@ -20,7 +20,7 @@ export default {
 }
 
 const portrait = (
-  <IconFrame
+  <AppIcon
     spacing="none"
     size="xsmall"
     url="photo.png"

--- a/src/stories/Icons.stories.tsx
+++ b/src/stories/Icons.stories.tsx
@@ -233,7 +233,7 @@ export default {
   component: MarketPlusIcon,
 }
 
-const IconFrame = styled.div<{ $backgroundColor: string }>(({ theme, $backgroundColor = 'transparent' }) => ({
+const AppIcon = styled.div<{ $backgroundColor: string }>(({ theme, $backgroundColor = 'transparent' }) => ({
   margin: theme.spacing.xxxsmall,
   paddingTop: theme.spacing.medium,
   paddingBottom: theme.spacing.xsmall,
@@ -268,7 +268,7 @@ function Template({ backgroundColor, ...args }: any) {
       }}
     >
       {Object.entries(icons).map(([name, Icon]) => (
-        <IconFrame
+        <AppIcon
           key={name}
           $backgroundColor={bgColor}
         >
@@ -284,7 +284,7 @@ function Template({ backgroundColor, ...args }: any) {
           >
             {/* {name.replace('Icon', '').replaceAll(/([a-z])([A-Z])/g, '$1&shy;$2')} */}
           </span>
-        </IconFrame>
+        </AppIcon>
       ))}
     </div>
   )

--- a/src/stories/ListBox.stories.tsx
+++ b/src/stories/ListBox.stories.tsx
@@ -2,8 +2,8 @@ import { Div, Flex } from 'honorable'
 import { Key, useState } from 'react'
 
 import {
+  AppIcon,
   Chip,
-  IconFrame,
   ListBox,
   ListBoxFooter,
   ListBoxFooterPlus,
@@ -18,7 +18,7 @@ export default {
 }
 
 const portrait = (
-  <IconFrame
+  <AppIcon
     spacing="none"
     size="xsmall"
     url="photo.png"

--- a/src/stories/Select.stories.tsx
+++ b/src/stories/Select.stories.tsx
@@ -3,11 +3,11 @@ import { Key, forwardRef, useState } from 'react'
 import styled from 'styled-components'
 
 import {
+  AppIcon,
   Button,
   CheckIcon,
   Chip,
   DropdownArrowIcon,
-  IconFrame,
   InfoIcon,
   ListBoxFooterPlus,
   ListBoxItem,
@@ -24,7 +24,7 @@ export default {
 }
 
 const portrait = (
-  <IconFrame
+  <AppIcon
     spacing="none"
     size="xsmall"
     url="photo.png"


### PR DESCRIPTION
Currently the component known as 'App Icon' in the figma design system is implemented as `<IconFrame>`, which is a name needed for different component that hasn't been implemented yet. There seems to be only one instance of this component in the app right now, so I think it's best to fix this now rather than live with less descriptive component names for the rest of time. This may potentially disrupt some in-progress work if you're using the `<IconFrame>` component. But should be an easy swap when you update the design system. I'll delay implementing the new 'Icon Frame' until the transition is complete.