### PR TITLE
Fix imports that break in NextJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pluralsh-design-system",
-  "version": "1.203.0",
+  "version": "1.204.0",
   "description": "Pluralsh Design System",
   "main": "dist/index.js",
   "files": [

--- a/src/components/ContentCard.tsx
+++ b/src/components/ContentCard.tsx
@@ -1,9 +1,7 @@
 import { Div, DivProps } from 'honorable'
 import { forwardRef } from 'react'
 
-import { Card } from '../index'
-
-import { CardProps } from './Card'
+import Card, { CardProps } from './Card'
 
 export type ContentCardProps = CardProps & {
   innerProps?: DivProps

--- a/src/components/ListBox.tsx
+++ b/src/components/ListBox.tsx
@@ -18,7 +18,7 @@ import styled, { CSSObject, useTheme } from 'styled-components'
 
 import { Item } from '@react-stately/collections'
 
-import { Card } from '../index'
+import Card from './Card'
 
 export const HEADER_KEY = '$$header$$'
 export const FOOTER_KEY = '$$footer$$'


### PR DESCRIPTION
Importing from ‘/index’ was breaking when using the design system in NextJS. This fixes that.