### PR TITLE
Improve Stepper component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pluralsh-design-system",
-  "version": "1.221.0",
+  "version": "1.222.0",
   "description": "Pluralsh Design System",
   "main": "dist/index.js",
   "files": [

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -29,7 +29,7 @@ import WrapWithIf from './WrapWithIf'
 type TooltipProps = {
   label: ReactNode
   placement?: Placement
-  children: JSX.Element
+  children?: JSX.Element
   displayOn?: 'hover' | 'click' | 'focus' | 'manual' | 'none'
   arrowProps?: DivProps
   manualOpen?: boolean

--- a/src/stories/Stepper.stories.tsx
+++ b/src/stories/Stepper.stories.tsx
@@ -1,6 +1,7 @@
+import { Flex } from 'honorable'
+
 import Stepper from '../components/Stepper'
 import type { StepperSteps } from '../components/Stepper'
-
 import BrowserIcon from '../components/icons/BrowserIcon'
 import CloudIcon from '../components/icons/CloudIcon'
 import GearTrainIcon from '../components/icons/GearTrainIcon'
@@ -13,9 +14,15 @@ export default {
 
 function Template(args: any) {
   return (
-    <Stepper
-      {...args}
-    />
+    <Flex
+      maxWidth={args.containerWidth || undefined}
+      background={args.showContainer ? 'rgba(255, 255, 255, 0.05)' : undefined}
+      overflow="auto"
+    >
+      <Stepper
+        {...args}
+      />
+    </Flex>
   )
 }
 
@@ -53,6 +60,10 @@ List01.args = {
 export const Vertical = Template.bind({})
 Vertical.args = {
   stepIndex: 1,
-  steps,
+  containerWidth: 170,
+  collapseAtWidth: 160,
+  forceCollapse: false,
+  showContainer: false,
   vertical: true,
+  steps,
 }


### PR DESCRIPTION
Added new feature to hide titles in vertical `Stepper` components. First, the text is allowed to wrap when the width is too small.

Second, I aded two new props
- `collapseAtWidth`: If set, when the component width drops below this value, then the step titles will be replaced by tooltips when hovering the circles
- `forceCollapse`: If set, the titles will be replaced by tooltips regardless of width

These are available to adjust in storybook and there's also `containerWith` and `showContainer` props there to help see the transitions. https://pluralsh-design--pr218-klink-stepper-improv-msq3p6z3.web.app/?path=/story/stepper--vertical