### PR TITLE
Fix forwardRef warning on Code component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pluralsh-design-system",
-  "version": "1.222.0",
+  "version": "1.223.0",
   "description": "Pluralsh Design System",
   "main": "dist/index.js",
   "files": [

--- a/src/components/Code.tsx
+++ b/src/components/Code.tsx
@@ -1,4 +1,6 @@
-import { forwardRef, useEffect, useState } from 'react'
+import {
+  RefObject, forwardRef, useEffect, useState,
+} from 'react'
 import {
   Button, Div, Flex, FlexProps,
 } from 'honorable'
@@ -15,7 +17,7 @@ type CodeProps = FlexProps & {
 
 const propTypes = {}
 
-function CodeRef({ children, language, ...props }: CodeProps) {
+function CodeRef({ children, language, ...props }: CodeProps, ref: RefObject<any>) {
   const [copied, setCopied] = useState(false)
   const [hover, setHover] = useState(false)
 
@@ -33,6 +35,7 @@ function CodeRef({ children, language, ...props }: CodeProps) {
 
   return (
     <Card
+      ref={ref}
       onMouseEnter={() => setHover(true)}
       onMouseLeave={() => setHover(false)}
       {...props}


### PR DESCRIPTION
`Code` component wasn't forwarding the ref, despite using forwardRef(). This fixes the warning:

`Warning: forwardRef render functions accept exactly two parameters: props and ref. Did you forget to use the ref parameter?`