### PR TITLE
Add hover state to RepositoryChip

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pluralsh-design-system",
-  "version": "1.230.0",
+  "version": "1.231.0",
   "description": "Pluralsh Design System",
   "main": "dist/index.js",
   "files": [

--- a/src/components/RepositoryChip.tsx
+++ b/src/components/RepositoryChip.tsx
@@ -45,10 +45,12 @@ function RepositoryChipRef({
       ref={ref}
       padding="xsmall"
       align="center"
-      backgroundColor="fill-two"
+      cursor="pointer"
       borderRadius="large"
       border={`1px solid ${checked ? 'border-outline-focused' : 'border-fill-two'}`}
-      cursor="pointer"
+      backgroundColor="fill-two"
+      _hover={{ backgroundColor: 'fill-two-hover' }}
+      transition="background-color 200ms ease"
       {...props}
     >
       {icon ? (


### PR DESCRIPTION
The top one has the hover state:
<img width="1420" alt="image" src="https://user-images.githubusercontent.com/4154003/196426478-0017609d-6c17-4d34-9a3f-e7c24dc1a0fd.png">
