### PR TITLE
ENG-688 update code block component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pluralsh-design-system",
-  "version": "1.237.0",
+  "version": "1.238.0",
   "description": "Pluralsh Design System",
   "main": "dist/index.js",
   "files": [

--- a/src/components/Code.tsx
+++ b/src/components/Code.tsx
@@ -1,6 +1,7 @@
 import {
   RefObject, forwardRef, useEffect, useState,
 } from 'react'
+import PropTypes from 'prop-types'
 import { Button, Div, Flex } from 'honorable'
 
 import styled from 'styled-components'
@@ -16,9 +17,14 @@ type CodeProps = Omit<CardProps, 'children'> & {
   children: string
   language?: string
   showLineNumbers?: boolean
+  showHeader?: boolean
 }
 
-const propTypes = {}
+const propTypes = {
+  language: PropTypes.string,
+  showLineNumbers: PropTypes.bool,
+  showHeader: PropTypes.bool,
+}
 
 const CodeHeader = styled.div<{ fillLevel: FillLevel }>(({ fillLevel, theme }) => ({
   ...theme.partials.text.overline,
@@ -65,7 +71,7 @@ const CopyButton = styled(CopyButtonBase)<{ verticallyCenter: boolean }>(({ vert
 }))
 
 function CodeRef({
-  children, language, showLineNumbers, ...props
+  children, language, showLineNumbers, showHeader, ...props
 }: CodeProps,
 ref: RefObject<any>) {
   const [copied, setCopied] = useState(false)
@@ -76,10 +82,9 @@ ref: RefObject<any>) {
     throw new Error('Code component expects a string as its children')
   }
 
-  const showHeader = !!language
-
-  children = children.trim()
-  const multiLine = !!children.match(/\r?\n/)
+  showHeader = showHeader === undefined ? !!language : showHeader
+  const codeString = children.trim()
+  const multiLine = !!codeString.match(/\r?\n/) || props.height
 
   useEffect(() => {
     if (copied) {
@@ -89,11 +94,12 @@ ref: RefObject<any>) {
     }
   }, [copied])
 
-  const handleCopy = () => window.navigator.clipboard.writeText(children).then(() => setCopied(true))
+  const handleCopy = () => window.navigator.clipboard.writeText(codeString).then(() => setCopied(true))
 
   return (
     <Card
       ref={ref}
+      overflow="hidden"
       onMouseEnter={() => setHover(true)}
       onMouseLeave={() => setHover(false)}
       {...props}
@@ -134,7 +140,7 @@ ref: RefObject<any>) {
                 showLineNumbers={showLineNumbers}
                 language={language}
               >
-                {children}
+                {codeString}
               </Highlight>
             </Div>
           </Div>
@@ -149,3 +155,4 @@ const Code = forwardRef(CodeRef)
 Code.propTypes = propTypes
 
 export default Code
+export { CodeProps }

--- a/src/components/Code.tsx
+++ b/src/components/Code.tsx
@@ -1,27 +1,85 @@
 import {
   RefObject, forwardRef, useEffect, useState,
 } from 'react'
-import {
-  Button, Div, Flex, FlexProps,
-} from 'honorable'
+import { Button, Div, Flex } from 'honorable'
+
+import styled from 'styled-components'
 
 import CopyIcon from './icons/CopyIcon'
-import Card from './Card'
+import Card, { CardProps } from './Card'
 import CheckIcon from './icons/CheckIcon'
 import Highlight from './Highlight'
+import { FillLevel, useFillLevel } from './contexts/FillLevelContext'
+import FileIcon from './icons/FileIcon'
 
-type CodeProps = FlexProps & {
-  children: string,
-  language?: string,
+type CodeProps = Omit<CardProps, 'children'> & {
+  children: string
+  language?: string
+  showLineNumbers?: boolean
 }
 
 const propTypes = {}
 
-function CodeRef({ children, language, ...props }: CodeProps, ref: RefObject<any>) {
+const CodeHeader = styled.div<{ fillLevel: FillLevel }>(({ fillLevel, theme }) => ({
+  ...theme.partials.text.overline,
+  minHeight: theme.spacing.xlarge + theme.spacing.xsmall * 2,
+  padding: `${theme.spacing.xsmall}px ${theme.spacing.medium}px`,
+  borderBottom:
+      fillLevel >= 1 ? theme.borders['fill-three'] : theme.borders['fill-two'],
+  color: 'text-light',
+  backgroundColor:
+      fillLevel >= 1 ? theme.colors['fill-three'] : theme.colors['fill-two'],
+  display: 'flex',
+  alignItems: 'center',
+  gap: theme.spacing.xsmall,
+}))
+
+function CopyButtonBase({
+  copied,
+  handleCopy,
+  className,
+}: {
+  copied: boolean
+  handleCopy: () => any
+  className?: string
+}) {
+  return (
+    <Button
+      className={className}
+      position="absolute"
+      floating
+      small
+      startIcon={copied ? <CheckIcon /> : <CopyIcon />}
+      onClick={handleCopy}
+    >
+      {copied ? 'Copied' : 'Copy'}
+    </Button>
+  )
+}
+const CopyButton = styled(CopyButtonBase)<{ verticallyCenter: boolean }>(({ verticallyCenter, theme }) => ({
+  position: 'absolute',
+  right: theme.spacing.medium,
+  top: verticallyCenter ? '50%' : theme.spacing.medium,
+  transform: verticallyCenter ? 'translateY(-50%)' : 'none',
+  boxShadow: theme.boxShadows.slight,
+}))
+
+function CodeRef({
+  children, language, showLineNumbers, ...props
+}: CodeProps,
+ref: RefObject<any>) {
   const [copied, setCopied] = useState(false)
   const [hover, setHover] = useState(false)
+  const fillLevel = useFillLevel()
 
-  if (typeof children !== 'string') throw new Error('Code component expects a string as its children')
+  if (typeof children !== 'string') {
+    throw new Error('Code component expects a string as its children')
+  }
+
+  const showHeader = !!language
+
+  children = children.trim()
+  const multiLine = !!children.match(/\r?\n/)
 
   useEffect(() => {
     if (copied) {
@@ -45,42 +103,41 @@ function CodeRef({ children, language, ...props }: CodeProps, ref: RefObject<any
         direction="column"
         height="100%"
       >
-        {!!language && (
-          <Div
-            paddingHorizontal="large"
-            paddingVertical="medium"
-            borderBottom="1px solid border"
-            overline
-            color="text-light"
-          >
-            {language}
-          </Div>
+        {showHeader && (
+          <CodeHeader fillLevel={fillLevel}>
+            <FileIcon />
+            <div>{language}</div>
+          </CodeHeader>
         )}
         <Div
-          minHeight="90px"
+          position="relative"
           height="100%"
-          overflow="auto"
-          alignItems="center"
+          overflow="hidden"
         >
-          {hover && (
-            <Button
-              small
-              position="absolute"
-              right="24px"
-              top={language ? '73px' : '24px'}
-              floating
-              startIcon={copied ? <CheckIcon /> : <CopyIcon />}
-              onClick={handleCopy}
-            >
-              {copied ? 'Copied' : 'Copy'}
-            </Button>
-          )}
-          <Highlight
-            language={language}
-            padding="large"
+          <Div
+            height="100%"
+            overflow="auto"
+            alignItems="center"
           >
-            {children}
-          </Highlight>
+            {hover && (
+              <CopyButton
+                copied={copied}
+                handleCopy={handleCopy}
+                verticallyCenter={!multiLine}
+              />
+            )}
+            <Div
+              paddingHorizontal="medium"
+              paddingVertical={multiLine ? 'medium' : 'small'}
+            >
+              <Highlight
+                showLineNumbers={showLineNumbers}
+                language={language}
+              >
+                {children}
+              </Highlight>
+            </Div>
+          </Div>
         </Div>
       </Flex>
     </Card>

--- a/src/components/Highlight.tsx
+++ b/src/components/Highlight.tsx
@@ -167,7 +167,7 @@ function HighlightRef({
     <MainWrap>
       {showLineNumbers && (
         <LineNumbers aria-hidden>
-          {lines.map((line, idx) => `${idx}${idx < lines.length - 1 ? '\n' : ''}`)}
+          {lines.map((line, idx) => `${idx + 1}${idx < lines.length - 1 ? '\n' : ''}`)}
         </LineNumbers>
       )}
       <StyledHighlight>

--- a/src/components/Highlight.tsx
+++ b/src/components/Highlight.tsx
@@ -1,18 +1,33 @@
-import { forwardRef, useEffect, useRef } from 'react'
-import { Pre, PreProps } from 'honorable'
+import {
+  forwardRef, useEffect, useMemo, useRef,
+} from 'react'
 import hljs from 'highlight.js/lib/core'
 import '../hljs'
 
 import styled from 'styled-components'
+import { ComponentPropsWithoutRef } from 'react-markdown/lib/ast-to-react'
 
-const StyledHighlightBase = styled.div(({ theme }) => ({
-  '.hljs': {
-    color: '#ebeff0',
-    ...theme.partials.text.code,
-  },
+const MainWrap = styled.div(({ theme }) => ({
+  display: 'flex',
+  gap: theme.spacing.large,
 }))
 
-const StyledHighlight = styled(StyledHighlightBase)(_ => `
+const StyledPre = styled.pre(({ theme }) => ({
+  ...theme.partials.text.code,
+  background: 'none',
+  margin: 0,
+  padding: 0,
+}))
+
+const LineNumbers = styled(StyledPre)(({ theme }) => ({
+  ...theme.partials.text.code,
+  pointerEvents: 'none',
+  userSelect: 'none',
+  display: 'flex',
+  textAlign: 'right',
+}))
+
+const StyledHighlight = styled.div(_ => `
 pre code.hljs {
   display: block;
   overflow-x: auto;
@@ -120,16 +135,26 @@ code.hljs {
   font-weight: 700;
 }`)
 
-type HighlightProps = PreProps & {
-  language: string
+type HighlightProps = Omit<ComponentPropsWithoutRef<'pre'>, 'children'> & {
+  language?: string
+  showLineNumbers?: boolean
+  children: string
 }
 
 const propTypes = {}
 
-function HighlightRef({ language, children, ...props } : HighlightProps) {
-  if (typeof children !== 'string') throw new Error('Highlight component expects a string as its children')
-
+function HighlightRef({
+  language,
+  children,
+  showLineNumbers,
+  ...props
+}: HighlightProps) {
+  if (typeof children !== 'string') {
+    throw new Error('Highlight component expects a string as its children')
+  }
   const codeRef = useRef()
+
+  const lines = useMemo(() => children.split(/\r?\n/), [children])
 
   useEffect(() => {
     if (hljs.getLanguage(language) && codeRef.current) {
@@ -139,19 +164,22 @@ function HighlightRef({ language, children, ...props } : HighlightProps) {
   }, [language, children])
 
   return (
-    <StyledHighlight>
-      <Pre
-        background="none"
-        margin="0"
-        padding="0"
-        lineHeight="22px"
-        className={language ? `language-${language}` : 'nohighlight'}
-        ref={codeRef}
-        {...props}
-      >
-        {children}
-      </Pre>
-    </StyledHighlight>
+    <MainWrap>
+      {showLineNumbers && (
+        <LineNumbers aria-hidden>
+          {lines.map((line, idx) => `${idx}${idx < lines.length - 1 ? '\n' : ''}`)}
+        </LineNumbers>
+      )}
+      <StyledHighlight>
+        <StyledPre
+          className={language ? `language-${language}` : 'nohighlight'}
+          ref={codeRef}
+          {...props}
+        >
+          {children}
+        </StyledPre>
+      </StyledHighlight>
+    </MainWrap>
   )
 }
 

--- a/src/stories/Button.stories.tsx
+++ b/src/stories/Button.stories.tsx
@@ -12,7 +12,9 @@ export default {
       control: {
         type: 'select',
         labels: {
-          '': 'Enabled',
+          // Can't have empty string as key for labels
+          // Breaks controls for every other component that appears after this
+          // '': 'Enabled',
           none: 'Disabled',
         },
       },

--- a/src/stories/Code.stories.tsx
+++ b/src/stories/Code.stories.tsx
@@ -12,15 +12,14 @@ export default {
       control: {
         type: 'boolean', min: 0, max: 6000, step: 100,
       },
-      hue: {
-        options: ['default', 'lighter', 'lightest'],
-        control: {
-          type: 'select',
-        },
+    },
+    showHeader: {
+      options: [undefined, true, false],
+      control: {
+        type: 'select', min: 0, max: 6000, step: 100,
       },
     },
   },
-
 }
 
 function Template(args:any) {
@@ -73,6 +72,13 @@ function Template(args:any) {
       </Code>
       <Code
         width="400px"
+        height="300px"
+        {...args}
+      >
+        One line with `height` specified
+      </Code>
+      <Code
+        width="400px"
         {...args}
       >
         {'Two lines\nTwo lines'}
@@ -87,7 +93,7 @@ function Template(args:any) {
       <Card padding="medium">
         <Code
           language="javascript"
-          width="600px"
+          {...args}
         >
           {jsCode}
         </Code>
@@ -99,4 +105,5 @@ function Template(args:any) {
 export const Default = Template.bind({})
 Default.args = {
   showLineNumbers: true,
+  showHeader: undefined,
 }

--- a/src/stories/Code.stories.tsx
+++ b/src/stories/Code.stories.tsx
@@ -1,15 +1,29 @@
 import { Flex } from 'honorable'
 
-import { Code } from '..'
+import { Card, Code } from '..'
 
 import { goCode, jsCode, tfCode } from '../constants'
 
 export default {
   title: 'Code',
   component: Code,
+  argTypes: {
+    showLineNumbers: {
+      control: {
+        type: 'boolean', min: 0, max: 6000, step: 100,
+      },
+      hue: {
+        options: ['default', 'lighter', 'lightest'],
+        control: {
+          type: 'select',
+        },
+      },
+    },
+  },
+
 }
 
-function Template() {
+function Template(args:any) {
   return (
     <Flex
       direction="column"
@@ -18,6 +32,7 @@ function Template() {
       <Code
         language="javascript"
         width="600px"
+        {...args}
       >
         {jsCode}
       </Code>
@@ -25,38 +40,63 @@ function Template() {
         language="terraform"
         width="600px"
         height="200px"
+        {...args}
       >
         {tfCode}
       </Code>
       <Code
         width="600px"
         height="100px"
+        {...args}
       >
         {jsCode}
       </Code>
       <Code
         language="go"
         width="400px"
+        {...args}
       >
         {goCode}
       </Code>
       <Code
         width="400px"
         language="js"
+        {...args}
       >
         console.log('test')
       </Code>
-      <Code width="400px">
+      <Code
+        width="400px"
+        {...args}
+      >
         One line
       </Code>
-      <Code width="400px">
+      <Code
+        width="400px"
+        {...args}
+      >
         {'Two lines\nTwo lines'}
       </Code>
-      <Code width="400px">
+      <Code
+        width="400px"
+        {...args}
+      >
         {'Three lines\nThree lines\nThree lines'}
       </Code>
+
+      <Card padding="medium">
+        <Code
+          language="javascript"
+          width="600px"
+        >
+          {jsCode}
+        </Code>
+      </Card>
     </Flex>
   )
 }
 
 export const Default = Template.bind({})
+Default.args = {
+  showLineNumbers: true,
+}


### PR DESCRIPTION
Update styling of `Code` component

[Figma](https://www.figma.com/file/9nkKaihJkJzFIgoBADk0yQ/Docs?node-id=1%3A64&viewport=-15071%2C-35%2C0.71)
[Linear](https://linear.app/pluralsh/issue/ENG-688/update-code-block-component)

Tabs functionality has been pushed back into a [new ticket](https://linear.app/pluralsh/issue/ENG-862/add-tabs-functionality-to-code-component) so as not to block Docs launch.