### PR TITLE
Restore ‘error’ colors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pluralsh-design-system",
-  "version": "1.240.0",
+  "version": "1.241.0",
   "description": "Pluralsh Design System",
   "main": "dist/index.js",
   "files": [

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -163,4 +163,10 @@ export const semanticColors = {
   'icon-success': green[200],
   'icon-warning': yellow[100],
   'icon-danger': red[200],
+  'icon-danger-critical': red[400],
+  // Deprecated (Remove after all 'error' colors converted to 'danger' in app)
+  'border-error': red[300],
+  'text-error': red[400],
+  'text-error-light': red[200],
+  'icon-error': red[200],
 }


### PR DESCRIPTION
Since the big app front-end refactor is still in progress, I’m restoring the ‘error’ colors until it’s safe to replace them all with ‘danger’ colors in the app.