### PR TITLE
Renovate built in version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pluralsh-design-system",
-  "version": "1.247.0",
+  "version": "1.248.0",
   "description": "Pluralsh Design System",
   "main": "dist/index.js",
   "files": [

--- a/renovate.json
+++ b/renovate.json
@@ -19,15 +19,7 @@
     },
     {
       "matchManagers": ["npm"],
-      "postUpgradeTasks": {
-        "commands": [
-          "yarn version minor"
-        ],
-        "fileFilters": [
-          "package.json",
-          ".yarn/versions/*.yml"
-        ]
-      }
+      "bumpVersion": "minor"
     }
   ],
   "separateMinorPatch": true


### PR DESCRIPTION
have renovate bump the version with it's built-in mechanism rather than using `yarn version minor` command.