### PR TITLE
enable auto-merging in renovate

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pluralsh-design-system",
-  "version": "1.248.0",
+  "version": "1.249.0",
   "description": "Pluralsh Design System",
   "main": "dist/index.js",
   "files": [

--- a/renovate.json
+++ b/renovate.json
@@ -19,6 +19,19 @@
     },
     {
       "matchManagers": ["npm"],
+      "matchUpdateTypes": ["patch", "pin", "digest"],
+      "automerge": true
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "automerge": true
+    },
+    {
+      "matchManagers": ["npm"],
       "bumpVersion": "minor"
     }
   ],


### PR DESCRIPTION
Enables auto-merging in renovate for patch versions, and up to minor versions for dev dependencies.