### PR TITLE
feat: specify engine in package.json + use in ci

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,10 +8,15 @@ jobs:
     name: Build and deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - name: 'Checkout'
+        uses: actions/checkout@v3
+      - name: Read Node.js version from package.json
+        run: echo ::set-output name=nodeVersion::$(node -p "require('./package.json').engines.node")
+        id: engines
+      - name: 'Setup Node'
+        uses: actions/setup-node@v3
         with:
-          node-version: 16.15.0
+          node-version: ${{ steps.engines.outputs.nodeVersion }}
       - run: yarn --immutable
       - run: yarn build:storybook
       - uses: FirebaseExtended/action-hosting-deploy@v0
@@ -29,10 +34,13 @@ jobs:
       with:
         fetch-depth: 0
         token: ${{ secrets.PLURAL_BOT_PAT }}
+    - name: Read Node.js version from package.json
+      run: echo ::set-output name=nodeVersion::$(node -p "require('./package.json').engines.node")
+      id: engines
     - name: 'Setup Node'
       uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: ${{ steps.engines.outputs.nodeVersion }}
         registry-url: 'https://registry.npmjs.org'
     - name: 'Install Dependencies'
       run: yarn install --immutable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,15 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - name: 'Checkout'
+        uses: actions/checkout@v3
+      - name: Read Node.js version from package.json
+        run: echo ::set-output name=nodeVersion::$(node -p "require('./package.json').engines.node")
+        id: engines
+      - name: 'Setup Node'
+        uses: actions/setup-node@v3
         with:
-          node-version: 16.15.0
+          node-version: ${{ steps.engines.outputs.nodeVersion }}
       - run: |
           yarn install --immutable
       - run: yarn build
@@ -26,10 +31,15 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - name: 'Checkout'
+        uses: actions/checkout@v3
+      - name: Read Node.js version from package.json
+        run: echo ::set-output name=nodeVersion::$(node -p "require('./package.json').engines.node")
+        id: engines
+      - name: 'Setup Node'
+        uses: actions/setup-node@v3
         with:
-          node-version: 16.15.0
+          node-version: ${{ steps.engines.outputs.nodeVersion }}
       - run: |
           yarn install --immutable
       - run: yarn build:storybook
@@ -40,10 +50,15 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - name: 'Checkout'
+        uses: actions/checkout@v3
+      - name: Read Node.js version from package.json
+        run: echo ::set-output name=nodeVersion::$(node -p "require('./package.json').engines.node")
+        id: engines
+      - name: 'Setup Node'
+        uses: actions/setup-node@v3
         with:
-          node-version: 16.15.0
+          node-version: ${{ steps.engines.outputs.nodeVersion }}
       - run: |
           yarn install --immutable
       - run: yarn lint
@@ -52,10 +67,15 @@ jobs:
     if: ${{ github.triggering_actor != 'plural-renovate[bot]' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - name: 'Checkout'
+        uses: actions/checkout@v3
+      - name: Read Node.js version from package.json
+        run: echo ::set-output name=nodeVersion::$(node -p "require('./package.json').engines.node")
+        id: engines
+      - name: 'Setup Node'
+        uses: actions/setup-node@v3
         with:
-          node-version: 16.15.0
+          node-version: ${{ steps.engines.outputs.nodeVersion }}
       - run: |
           yarn install --immutable
       - run: yarn build:storybook

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "fix": "eslint src --ext ts,tsx,js,jsx --fix",
     "prepublishOnly": "npm run build"
   },
+  "engines": {
+    "node": "16.15.0"
+  },
   "dependencies": {
     "@floating-ui/react-dom-interactions": "0.11.0",
     "@react-aria/button": "3.6.2",


### PR DESCRIPTION
The Node version specified in our CI was getting diverged since there was no single source of truth. This PR specifies the node version in the `package.json` and our CI will read it from there and install the appropriate version. This will also be useful for keeping our CI up to date with our package as Renovate might update the node version.