### PR TITLE
feat: Update icon frame and allow customizing progress bar colors

### DIFF
--- a/src/components/IconFrame.tsx
+++ b/src/components/IconFrame.tsx
@@ -8,24 +8,26 @@ import { ButtonBase, Flex, FlexProps } from 'honorable'
 import { useTheme } from 'styled-components'
 
 import Tooltip, { TooltipProps } from './Tooltip'
-import { useFillLevel } from './contexts/FillLevelContext'
-import type { FillLevel } from './contexts/FillLevelContext'
 
-type Hue = 'none' | 'default' | 'lighter' | 'lightest'
 type Size = 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge'
+type Type = 'secondary' | 'tertiary' | 'floating'
 
-const parentFillLevelToHue: Record<FillLevel, Hue> = {
-  0: 'none',
-  1: 'default',
-  2: 'lighter',
-  3: 'lightest',
+const typeToBG: Record<Type, string> = {
+  secondary: 'transparent',
+  tertiary: 'transparent',
+  floating: 'fill-two',
 }
 
-const hueToHoverBG: Record<Hue, string> = {
-  none: 'fill-zero-hover',
-  default: 'fill-one-hover',
-  lighter: 'fill-two-hover',
-  lightest: 'fill-three-hover',
+const typeToHoverBG: Record<Type, string> = {
+  secondary: 'action-input-hover',
+  tertiary: 'action-input-hover',
+  floating: 'fill-two-hover',
+}
+
+const typeToBorder: Record<Type, string> = {
+  secondary: '1px solid border-input',
+  tertiary: '1px solid transparent',
+  floating: '1px solid border-input',
 }
 
 const sizeToIconSize: Record<Size, number> = {
@@ -45,32 +47,27 @@ const sizeToFrameSize: Record<Size, number> = {
 }
 
 type IconFrameProps = Omit<FlexProps, 'size'> & {
-  hue?: Hue
   clickable?: boolean
   textValue: string
   icon: ReactElement
   size?: Size
   tooltip?: boolean | ReactNode
   tooltipProps?: Partial<TooltipProps>
+  type?: Type
 }
 
 const IconFrame = forwardRef<HTMLDivElement, IconFrameProps>(({
   icon,
   size = 'medium',
-  hue,
   textValue,
   clickable = false,
   tooltip,
   tooltipProps,
+  type = 'tertiary',
   ...props
 },
 ref) => {
   const theme = useTheme()
-  const parentFillLevel = useFillLevel()
-
-  if (!hue) {
-    hue = parentFillLevelToHue[parentFillLevel]
-  }
 
   icon = cloneElement(icon, { size: sizeToIconSize[size] })
   if (tooltip && typeof tooltip === 'boolean') {
@@ -85,6 +82,8 @@ ref) => {
       justifyContent="center"
       width={sizeToFrameSize[size]}
       height={sizeToFrameSize[size]}
+      backgroundColor={typeToBG[type]}
+      border={typeToBorder[type]}
       borderRadius={theme.borderRadiuses.medium}
       aria-label={textValue}
       {...{ '&:focus,&:focus-visible': { outline: 'none' } }}
@@ -92,8 +91,6 @@ ref) => {
       {...{
         '&,&:any-link': {
           textDecoration: 'none',
-          border: 'unset',
-          background: 'unset',
           color: 'unset',
           appearance: 'unset',
         },
@@ -104,10 +101,7 @@ ref) => {
         role: 'button',
         cursor: 'pointer',
         '&:hover': {
-          backgroundColor:
-              clickable
-              && (theme.colors[hueToHoverBG[hue]]
-                || theme.colors[hueToHoverBG.default]),
+          backgroundColor: clickable && theme.colors[typeToHoverBG[type]],
         },
       })}
       {...props}

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -8,6 +8,8 @@ export type Props = {
   progress?: number,
   complete?: boolean,
   height?: number,
+  progressColor?: string,
+  completeColor?: string,
 }
 
 const keyframesOuter = keyframes`
@@ -98,6 +100,8 @@ export default function ProgressBar({
   paused = false,
   progress,
   height = 6,
+  progressColor = 'blue.200',
+  completeColor = 'border-success',
   ...props
 }: Props) {
   let fill
@@ -117,7 +121,7 @@ export default function ProgressBar({
         left={0}
         top={0}
         bottom={0}
-        backgroundColor={progress >= 1 || complete ? 'border-success' : 'blue.200'}
+        backgroundColor={progress >= 1 || complete ? completeColor : progressColor}
         right={`${(1 - progress) * 100}%`}
       />
     )

--- a/src/stories/IconFrame.stories.tsx
+++ b/src/stories/IconFrame.stories.tsx
@@ -5,22 +5,16 @@ import {
   Text,
 } from 'honorable'
 
-import { FillLevel, FillLevelProvider } from '../components/contexts/FillLevelContext'
-
-import {
-  Card,
-  IconFrame,
-  IconFrameProps,
-  TrashCanIcon,
-  WrapWithIf,
-} from '../index'
+import { IconFrame, IconFrameProps, TrashCanIcon } from '../index'
 
 export default {
   title: 'Icon Frame',
   component: IconFrame,
 }
 
-const fillLevels: FillLevel[] = [0, 1, 2, 3]
+type Type = 'secondary' | 'tertiary' | 'floating'
+
+const types: Type[] = ['secondary', 'tertiary', 'floating']
 
 const sizes: IconFrameProps['size'][] = [
   'xsmall',
@@ -38,13 +32,13 @@ function Template({
   tooltipProps,
   ...props
 }: Partial<IconFrameProps>) {
-  return fillLevels.map(fillLevel => (
-    <Div key={fillLevel}>
+  return types.map(type => (
+    <Div key={type}>
       <H1
         caption
         marginBottom="xxsmall"
       >
-        On fillLevel={`{${fillLevel}}`}
+        type="{type}"
       </H1>
       <Flex
         gap="xsmall"
@@ -53,34 +47,19 @@ function Template({
         flexWrap="wrap"
       >
         {sizes.map(size => (
-          <Card
-            key={size}
-            display="flex"
-            width="max-content"
-            paddingVertical="xsmall"
-            paddingHorizontal="medium"
-            flexDirection="row"
-            alignItems="center"
-            gap="medium"
-            fillLevel={fillLevel}
-            {...(fillLevel === 0 ? { backgroundColor: 'transparent' } : {})}
-          >
-            <WrapWithIf
-              condition={fillLevel === 0}
-              wrapper={<FillLevelProvider value={fillLevel} />}
-            >
-              <Text caption>size="{size}"</Text>
-              <IconFrame
-                size={size || 'medium'}
-                clickable={clickable === undefined ? true : clickable}
-                icon={icon || <TrashCanIcon />}
-                textValue={textValue || 'Delete'}
-                tooltip={tooltip}
-                tooltipProps={tooltipProps}
-                {...props}
-              />
-            </WrapWithIf>
-          </Card>
+          <>
+            <Text caption>size="{size}"</Text>
+            <IconFrame
+              size={size || 'medium'}
+              clickable={clickable === undefined ? true : clickable}
+              icon={icon || <TrashCanIcon />}
+              textValue={textValue || 'Delete'}
+              tooltip={tooltip}
+              tooltipProps={tooltipProps}
+              type={type}
+              {...props}
+            />
+          </>
         ))}
       </Flex>
     </Div>


### PR DESCRIPTION
Update icon frame according to design: https://www.figma.com/file/i3IQooR2YCCXiCJNL98lWr/%F0%9F%8E%A8-Official-Design-System?node-id=3236%3A13864&t=6Rm8Psztsk1w5gi1-4

Allow changing progress bar colors.

Both changes are required for https://github.com/pluralsh/console/pull/125.