### PR TITLE
fix: Small table styling update

### DIFF
--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -213,6 +213,7 @@ const Td = styled.td<{
   display: 'flex',
   flexDirection: 'column',
   justifyContent: 'center',
+  alignItems: 'center',
   height: 'auto',
   minHeight: 52,
 
@@ -232,6 +233,7 @@ const Td = styled.td<{
   ...(truncateColumn
     ? {
       '*': {
+        width: '100%',
         whiteSpace: 'nowrap',
         overflow: 'hidden',
         textOverflow: 'ellipsis',

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -207,13 +207,14 @@ const Td = styled.td<{
   loose?: boolean
   stickyColumn: boolean
   truncateColumn: boolean
+  center?: boolean
 }>(({
-  theme, firstRow, loose, stickyColumn, truncateColumn = false,
+  theme, firstRow, loose, stickyColumn, truncateColumn = false, center,
 }) => ({
   display: 'flex',
   flexDirection: 'column',
   justifyContent: 'center',
-  alignItems: 'center',
+  alignItems: center ? 'center' : 'flex-start',
   height: 'auto',
   minHeight: 52,
 
@@ -327,6 +328,7 @@ function FillerRow({
         }}
         colSpan={columns.length}
         truncateColumn={false}
+        center={false}
         {...props}
       />
     </Tr>
@@ -550,6 +552,7 @@ forwardRef: Ref<any>) {
                         loose={loose}
                         stickyColumn={stickyColumn}
                         truncateColumn={cell.column?.columnDef?.meta?.truncate}
+                        center={cell.column?.columnDef?.meta?.center}
                       >
                         {flexRender(cell.column.columnDef.cell,
                           cell.getContext())}

--- a/src/types/react-table.d.ts
+++ b/src/types/react-table.d.ts
@@ -5,5 +5,6 @@ declare module '@tanstack/table-core' {
   interface ColumnMeta<TData extends RowData, TValue> {
     truncate?: boolean
     gridTemplate?: string
+    center?: boolean
   }
 }


### PR DESCRIPTION
A long line with a public key overlapped when truncated and `width` was not set.

#### Before
![image](https://user-images.githubusercontent.com/2285385/220335111-2533436e-3374-44ac-b633-5c31e93cbd5b.png)

#### After
![image](https://user-images.githubusercontent.com/2285385/220335568-3df137b4-6cf5-46bb-90c4-4b9f797330ee.png)

Truncated fields with template grid size set were not aligned to the center.

#### Before
![image](https://user-images.githubusercontent.com/2285385/220335408-83fb0194-738e-43a9-b556-6f00aedd8939.png)

#### After
![image](https://user-images.githubusercontent.com/2285385/220335516-1bad30ae-7200-4cab-92b0-d2225c70cdc4.png)

