### PR TITLE
feat: New Layer component + Toast improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "@storybook/react": "7.0.0-beta.49",
     "@storybook/react-vite": "7.0.0-beta.49",
     "@storybook/testing-library": "0.0.14-next.1",
+    "@types/react-dom": "18.0.11",
     "@types/react-transition-group": "4.4.5",
     "@types/styled-components": "5.1.26",
     "@typescript-eslint/eslint-plugin": "5.52.0",

--- a/src/components/Layer.tsx
+++ b/src/components/Layer.tsx
@@ -1,0 +1,268 @@
+import { useOutsideClick } from 'honorable'
+import {
+  MutableRefObject,
+  PropsWithChildren,
+  forwardRef,
+  useRef,
+} from 'react'
+import { createPortal } from 'react-dom'
+import {
+  TransitionFrom,
+  TransitionTo,
+  animated,
+  useTransition,
+} from 'react-spring'
+import styled, { useTheme } from 'styled-components'
+
+type GetTransitionProps = {
+  isOpen: boolean
+  type: 'slide' | 'fade' | 'scale'
+  direction: 'up' | 'down' | 'right' | 'left'
+}
+
+type AnimationType =
+  | 'fade'
+  | 'scale'
+  | 'slide'
+  | 'slide-up'
+  | 'slide-down'
+  | 'slide-left'
+  | 'slide-right'
+  | 'slide-horizontal'
+  | 'slide-vertical'
+
+const getTransitionProps = ({
+  isOpen,
+  type,
+  direction,
+}: GetTransitionProps) => {
+  const translateKey = `translate${
+    direction === 'up' || direction === 'down' ? 'Y' : 'X'
+  }`
+  let from:Record<string, any> = {
+    opacity: 0,
+  }
+  let to:Record<string, any> = {
+    opacity: 1,
+  }
+
+  if (type === 'slide') {
+    from = {
+      ...from,
+      [translateKey]:
+        direction === 'down' || direction === 'right' ? '-100%' : '100%',
+    }
+    to = {
+      ...to,
+      [translateKey]: '0%',
+    }
+  }
+
+  if (type === 'scale') {
+    from = {
+      ...from,
+      scale: '30%',
+    }
+    to = {
+      ...to,
+      scale: '100%',
+    }
+  }
+
+  return {
+    from,
+    enter: to,
+    leave: from,
+    config: isOpen
+      ? {
+        mass: 0.6,
+        tension: 280,
+        velocity: 0.02,
+      }
+      : {
+        mass: 0.6,
+        tension: 400,
+        velocity: 0.02,
+        restVelocity: 0.1,
+      },
+  }
+}
+
+export type LayerPositionType =
+  | 'bottom'
+  | 'bottom-left'
+  | 'bottom-right'
+  | 'center'
+  | 'hidden'
+  | 'left'
+  | 'right'
+  | 'top'
+  | 'top-left'
+  | 'top-right'
+
+export type MarginType = {
+  vertical?: string | number | undefined | null
+  horizontal?: string | number | undefined | null
+  top?: string | number | undefined | null
+  bottom?: string | number | undefined | null
+  left?: string | number | undefined | null
+  right?: string | number | undefined | null
+}
+
+const LayerWrapper = styled.div<{ position: LayerPositionType }>(({ position }) => ({
+  position: 'absolute',
+
+  pointerEvents: 'none',
+  '& > *': {
+    pointerEvents: 'auto',
+  },
+  display: position === 'hidden' ? 'hidden' : 'flex',
+  alignItems: position.startsWith('top')
+    ? 'start'
+    : position.startsWith('bottom')
+      ? 'end'
+      : 'center',
+  justifyContent: position.endsWith('left')
+    ? 'start'
+    : position.endsWith('right')
+      ? 'end'
+      : 'center',
+  top: 0,
+  left: 0,
+  right: 0,
+  bottom: 0,
+}))
+
+function LayerRef({
+  position,
+  animation = 'slide',
+  margin,
+  children,
+  onClickOutside,
+  show,
+}: PropsWithChildren<{
+    show: boolean
+    position: LayerPositionType
+    animation?: AnimationType
+  margin?: MarginType
+    onClickOutside?: ()=>void
+  }>,
+ref: MutableRefObject<HTMLDivElement>) {
+  const theme = useTheme()
+  const internalRef = useRef<HTMLDivElement>()
+  const finalRef = ref || internalRef
+
+  useOutsideClick(finalRef, () => {
+    onClickOutside?.()
+  })
+
+  if (typeof margin === 'string' || typeof margin === 'number') {
+    margin = {
+      vertical: margin,
+      horizontal: margin,
+    }
+  }
+  if (typeof margin === 'object') {
+    margin = {
+      ...(margin.top ? { top: margin.top } : {}),
+      ...(margin.bottom ? { top: margin.bottom } : {}),
+      ...(margin.left ? { top: margin.left } : {}),
+      ...(margin.right ? { top: margin.right } : {}),
+      ...(margin.vertical
+        ? {
+          top: margin.vertical,
+          bottom: margin.vertical,
+        }
+        : {}),
+      ...(margin.horizontal
+        ? {
+          left: margin.horizontal,
+          right: margin.horizontal,
+        }
+        : {}),
+    }
+  }
+  else {
+    margin = {}
+  }
+  for (const [key, value] of Object.entries(margin)) {
+    margin[key] = theme.spacing[value] || value
+  }
+  let animationDirection: GetTransitionProps['direction'] = 'down'
+  let animationType: GetTransitionProps['type'] = 'slide'
+
+  if (animation.startsWith('fade')) {
+    animationType = 'fade'
+    animationDirection = undefined
+  }
+  else if (animation === 'scale') {
+    animationType = 'scale'
+    animationDirection = undefined
+  }
+  else if (animation === 'slide') {
+    if (position === 'center') {
+      animationType = 'scale'
+      animationDirection = undefined
+    }
+    else {
+      animationType = 'slide'
+      animationDirection = position.startsWith('top')
+        ? 'down'
+        : position.startsWith('bottom')
+          ? 'up'
+          : position.endsWith('left')
+            ? 'right'
+            : position.endsWith('right')
+              ? 'left'
+              : 'down'
+    }
+  }
+  else if (animation.startsWith('slide')) {
+    animationType = 'slide'
+    const tempDir = animation.split('-')[1]
+
+    animationDirection = tempDir === 'up' ? 'up' : 'down'
+    if (tempDir === 'horizontal') {
+      animationDirection = position.endsWith('right') ? 'left' : 'right'
+    }
+    else if (tempDir === 'vertical') {
+      animationDirection = position.endsWith('bottom') ? 'up' : 'down'
+    }
+  }
+
+  const transitionProps = getTransitionProps({
+    isOpen: show,
+    direction: animationDirection,
+    type: animationType,
+  })
+  const transitions = useTransition(show ? [true] : [], transitionProps)
+
+  if (!document) {
+    return null
+  }
+  const portalElt = document?.getElementById(theme.portals.default.id)
+
+  const portalContent = (
+    <LayerWrapper position={position}>
+      {transitions(styles => {
+        console.log('transitions inner', styles)
+
+        return (
+          <animated.div
+            className="animated"
+            ref={finalRef}
+            style={{ ...styles }}
+          >
+            {children}
+          </animated.div>
+        )
+      })}
+    </LayerWrapper>
+  )
+
+  return createPortal(portalContent, portalElt)
+}
+
+const Layer = forwardRef(LayerRef)
+
+export default Layer

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,4 +1,3 @@
-import { Layer, LayerPositionType } from 'grommet'
 import { FlexProps } from 'honorable'
 import {
   Dispatch,
@@ -9,57 +8,34 @@ import {
   useState,
 } from 'react'
 
-
-const getTransitionProps = (isOpen: boolean, direction: 'up' | 'down' | 'right' | 'left') => {
-  translate = {
-    [`translate${direction === 'up' || direction==='down' ? Y : X}`]
-  }
-  return ({
-  from: { opacity: 0, translateX: `${CARD_WIDTH + 24}px` },
-  enter: { opacity: 1, translateX: '0px' },
-  leave: { opacity: 0, translateX: `${CARD_WIDTH + 24}px` },
-  config: isOpen
-    ? {
-      mass: 0.6,
-      tension: 280,
-      velocity: 0.02,
-    }
-    : {
-      mass: 0.6,
-      tension: 400,
-      velocity: 0.02,
-      restVelocity: 0.1,
-    },
-})}
-
-type LayerPositionType = "bottom" | "bottom-left" | "bottom-right" | "center" | "hidden" | "left" | "right" | "top" | "top-left" | "top-right"
-function Layer = function() {
-
-}
-
-
 import Banner from './Banner'
+import Layer, { LayerPositionType } from './Layer'
 
 export type Severity = 'info' | 'success' | 'error'
 
 type ToastProps = {
-  position?: LayerPositionType,
-  closeTimeout?: number,
-  onClose?: Dispatch<void>,
-  severity?: Severity,
+  position?: LayerPositionType
+  closeTimeout?: number
+  onClose?: Dispatch<void>
+  severity?: Severity
 } & FlexProps
 
 const defaults = {
-  closeTimeout: 10000, // 10 seconds
+  closeTimeout: 99999999, // 10000, // 10 seconds
   position: 'bottom-right' as LayerPositionType,
   onClose: () => {},
   severity: 'info' as Severity,
 }
 
 const Toast = forwardRef(({
-  position = defaults.position, closeTimeout = defaults.closeTimeout, onClose = defaults.onClose,
-  severity = defaults.severity, children, ...props
-}: ToastProps, ref:Ref<any>): JSX.Element => {
+  position = defaults.position,
+  closeTimeout = defaults.closeTimeout,
+  onClose = defaults.onClose,
+  severity = defaults.severity,
+  children,
+  ...props
+}: ToastProps,
+ref: Ref<any>): JSX.Element => {
   const [open, setOpen] = useState(true)
   const close = useCallback(() => {
     setOpen(false)
@@ -72,15 +48,10 @@ const Toast = forwardRef(({
     return () => clearTimeout(timer)
   })
 
-  if (!open) {
-    return null
-  }
-
   return (
     <Layer
+      show={open}
       position={position}
-      plain
-      modal={false}
       ref={ref}
     >
       <Banner
@@ -95,18 +66,21 @@ const Toast = forwardRef(({
 })
 
 type GraphQLToastProps = {
-  error: {graphQLErrors: Array<{message: string}>},
+  error: { graphQLErrors: Array<{ message: string }> }
   header: string
 } & ToastProps
 
 function GraphQLToast({
-  error, header, ...props
+  error,
+  header,
+  ...props
 }: GraphQLToastProps): JSX.Element {
   return (
     <Toast
       severity="error"
       {...props}
-    >{header}: {error?.graphQLErrors[0]?.message}
+    >
+      {header}: {error?.graphQLErrors[0]?.message}
     </Toast>
   )
 }

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -9,6 +9,35 @@ import {
   useState,
 } from 'react'
 
+
+const getTransitionProps = (isOpen: boolean, direction: 'up' | 'down' | 'right' | 'left') => {
+  translate = {
+    [`translate${direction === 'up' || direction==='down' ? Y : X}`]
+  }
+  return ({
+  from: { opacity: 0, translateX: `${CARD_WIDTH + 24}px` },
+  enter: { opacity: 1, translateX: '0px' },
+  leave: { opacity: 0, translateX: `${CARD_WIDTH + 24}px` },
+  config: isOpen
+    ? {
+      mass: 0.6,
+      tension: 280,
+      velocity: 0.02,
+    }
+    : {
+      mass: 0.6,
+      tension: 400,
+      velocity: 0.02,
+      restVelocity: 0.1,
+    },
+})}
+
+type LayerPositionType = "bottom" | "bottom-left" | "bottom-right" | "center" | "hidden" | "left" | "right" | "top" | "top-left" | "top-right"
+function Layer = function() {
+
+}
+
+
 import Banner from './Banner'
 
 export type Severity = 'info' | 'success' | 'error'

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,7 +86,7 @@ export { Toast, GraphQLToast } from './components/Toast'
 export { default as WrapWithIf } from './components/WrapWithIf'
 export type { AppProps, AppListProps, AppMenuAction } from './components/AppList'
 export { AppList } from './components/AppList'
-
+export { default as Layer } from './components/Layer'
 // Hooks
 export { default as usePrevious } from './hooks/usePrevious'
 export { default as useUnmount } from './hooks/useUnmount'

--- a/src/stories/Toast.stories.tsx
+++ b/src/stories/Toast.stories.tsx
@@ -12,18 +12,24 @@ export default {
       options: ['info', 'success', 'error'],
       control: { type: 'radio' },
     },
+    closeTimeout: {
+      control: {
+        type: 'number',
+      },
+    },
   },
 }
 
 type Args = {
   severity: Severity,
+  closeTimeout?: number,
 }
 
 function Template(args: Args) {
-  const [visible, setVisible] = useState(false)
+  const [showToast, setShowToast] = useState(false)
   const [position, setPosition] = useState('' as LayerPositionType)
   const handleClick = (visible: boolean, position: LayerPositionType) => {
-    setVisible(visible)
+    setShowToast(visible)
     setPosition(position)
   }
 
@@ -60,17 +66,16 @@ function Template(args: Args) {
         <Button onClick={() => handleClick(true, 'bottom-right')}>Bottom Right</Button>
       </Flex>
 
-      {visible
-        && (
-          <Toast
-            position={position}
-            onClose={() => setVisible(false)}
-            margin="large"
-            severity={args.severity}
-          >
-            Hello
-          </Toast>
-        )}
+      <Toast
+        show={showToast}
+        position={position}
+        onClose={() => setShowToast(false)}
+        margin="large"
+        severity={args.severity}
+        closeTimeout={args.closeTimeout}
+      >
+        Hello
+      </Toast>
     </Flex>
   )
 }
@@ -84,20 +89,17 @@ function GraphQLTemplate() {
   return (
     <Flex>
       <Button onClick={() => handleClick(true)}>Show</Button>
-
-      {visible
-        && (
-          <GraphQLToast
-            margin="large"
-            onClose={() => setVisible(false)}
-            error={{
-              graphQLErrors: [{
-                message: 'XYZ could not be found',
-              }],
-            }}
-            header="404 Not Found"
-          />
-        )}
+      <GraphQLToast
+        show={visible}
+        margin="large"
+        onClose={() => setVisible(false)}
+        error={{
+          graphQLErrors: [{
+            message: 'XYZ could not be found',
+          }],
+        }}
+        header="404 Not Found"
+      />
     </Flex>
   )
 }
@@ -106,6 +108,7 @@ export const Default = Template.bind({})
 
 Default.args = {
   severity: 'success',
+  closeTimeout: undefined,
 }
 
 export const GraphQL = GraphQLTemplate.bind({})

--- a/yarn.lock
+++ b/yarn.lock
@@ -2613,6 +2613,7 @@ __metadata:
     "@tanstack/react-table": 8.7.9
     "@tanstack/react-virtual": 3.0.0-beta.48
     "@types/chroma-js": 2.1.5
+    "@types/react-dom": 18.0.11
     "@types/react-transition-group": 4.4.5
     "@types/styled-components": 5.1.26
     "@typescript-eslint/eslint-plugin": 5.52.0
@@ -5338,6 +5339,15 @@ __metadata:
   version: 1.2.4
   resolution: "@types/range-parser@npm:1.2.4"
   checksum: b7c0dfd5080a989d6c8bb0b6750fc0933d9acabeb476da6fe71d8bdf1ab65e37c136169d84148034802f48378ab94e3c37bb4ef7656b2bec2cb9c0f8d4146a95
+  languageName: node
+  linkType: hard
+
+"@types/react-dom@npm:18.0.11":
+  version: 18.0.11
+  resolution: "@types/react-dom@npm:18.0.11"
+  dependencies:
+    "@types/react": "*"
+  checksum: 579691e4d5ec09688087568037c35edf8cfb1ab3e07f6c60029280733ee7b5c06d66df6fcc90786702c93ac8cb13bc7ff16c79ddfc75d082938fbaa36e1cdbf4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Added a new `Layer` component that is _somewhat_ backward compatible with grommet's Layer component. Need this for cookie consent banner, and to eventually replace grommet's Layer throughout our apps.
  - Now has nicer transition animations that match our other component transitions
  - Transition directions are more customizable
- Updated `Toasts` to use new Layer component
  - Setting `closeTimeout` to `none` or a negative value will cause the Toast to stay open until manually closed.
  - One breaking change is if you simply unmount the Toast, you won't get the exit animation anymore. Instead leave the toast always mounted and set/unset the `show` prop. Also added new `onCloseComplete` callback prop so you could still unmount the Toast after the exit animation is done if you'd like, but it's unnecessary, as nothing will be mounted in the DOM if you set `show={false}` and the exit animation is done.
