### PR TITLE
fix: Use container query to properly size pricing calculator

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "react-virtual": "2.10.4",
     "rehype-raw": "6.1.1",
     "resize-observer-polyfill": "1.5.1",
+    "styled-container-query": "1.3.5",
     "use-immer": "0.8.1"
   },
   "devDependencies": {

--- a/src/components/pricingcalculator/PricingCalculator.tsx
+++ b/src/components/pricingcalculator/PricingCalculator.tsx
@@ -2,7 +2,12 @@ import { forwardRef, useMemo, useState } from 'react'
 
 import Callout from '../Callout'
 
-import { PROVIDERS, PricingCalculatorWrap, estimateProviderCost } from './misc'
+import {
+  PROVIDERS,
+  PricingCalculatorContainerQuery,
+  PricingCalculatorWrap,
+  estimateProviderCost,
+} from './misc'
 import AppsControl from './controls/AppsControl'
 import ProviderControl from './controls/ProvidersControl'
 import Cost from './costs/Cost'
@@ -28,49 +33,51 @@ const PricingCalculator = forwardRef<HTMLDivElement, PricingCalculatorProps>(({ 
       ref={ref}
       title="Estimate your cloud cost."
     >
-      <PricingCalculatorWrap>
-        <p>
-          Estimate your cloud cost to get started with Plural open-source.
-        </p>
-        <div className="content with-padding">
-          <div className="column">
-            <ProviderControl
-              header="Cloud provider"
-              providerId={providerId}
-              setProviderId={setProviderId}
-            />
-            <AppsControl
-              header="Applications"
-              apps={apps}
-              setApps={setApps}
-            />
+      <PricingCalculatorContainerQuery>
+        <PricingCalculatorWrap>
+          <p>
+            Estimate your cloud cost to get started with Plural open-source.
+          </p>
+          <div className="content with-padding">
+            <div className="column">
+              <ProviderControl
+                header="Cloud provider"
+                providerId={providerId}
+                setProviderId={setProviderId}
+              />
+              <AppsControl
+                header="Applications"
+                apps={apps}
+                setApps={setApps}
+              />
+            </div>
+            <div className="column">
+              <Costs>
+                <Cost
+                  cost={providerCost?.k8s}
+                  label={`${provider?.name} Kubernetes cost`}
+                  tooltip="Cost to deploy this provider's managed version of Kubernetes."
+                />
+                <Cost
+                  cost={providerCost?.infra}
+                  label={`${provider?.name} infrastructure price`}
+                  tooltip="Cost to provision and run standard instances on this provider."
+                />
+                <Cost
+                  cost={providerCost?.app}
+                  label="Application infrastructure"
+                  tooltip="Cost to deploy and run selected number of applications. Default setup includes headroom for a few applications and will scale to meet additional needs."
+                />
+              </Costs>
+              <TotalCost
+                providerCost={providerCost?.total}
+                provider={provider?.name}
+                marginTop={24}
+              />
+            </div>
           </div>
-          <div className="column">
-            <Costs>
-              <Cost
-                cost={providerCost?.k8s}
-                label={`${provider?.name} Kubernetes cost`}
-                tooltip="Cost to deploy this provider's managed version of Kubernetes."
-              />
-              <Cost
-                cost={providerCost?.infra}
-                label={`${provider?.name} infrastructure price`}
-                tooltip="Cost to provision and run standard instances on this provider."
-              />
-              <Cost
-                cost={providerCost?.app}
-                label="Application infrastructure"
-                tooltip="Cost to deploy and run selected number of applications. Default setup includes headroom for a few applications and will scale to meet additional needs."
-              />
-            </Costs>
-            <TotalCost
-              providerCost={providerCost?.total}
-              provider={provider?.name}
-              marginTop={24}
-            />
-          </div>
-        </div>
-      </PricingCalculatorWrap>
+        </PricingCalculatorWrap>
+      </PricingCalculatorContainerQuery>
     </Callout>
   )
 })

--- a/src/components/pricingcalculator/PricingCalculatorExtended.tsx
+++ b/src/components/pricingcalculator/PricingCalculatorExtended.tsx
@@ -10,6 +10,7 @@ import Card, { CardProps } from '../Card'
 
 import {
   PROVIDERS,
+  PricingCalculatorContainerQuery,
   PricingCalculatorWrap,
   estimatePluralCost,
   estimateProviderCost,
@@ -50,81 +51,83 @@ const PricingCalculatorExtended = forwardRef<HTMLDivElement, CardProps>((props, 
       {...props}
       ref={ref}
     >
-      <PricingCalculatorWrap>
-        <div className="content">
-          <div className="column">
-            <ProviderControl
-              header="What cloud provider will you use?"
-              providerId={providerId}
-              setProviderId={setProviderId}
-            />
-            <ClustersControl
-              clusters={clusters}
-              setClusters={setClusters}
-            />
-            <AppsControl
-              header="How many applications do you plan to install?"
-              caption="The default deployment includes headroom for a few applications, but will scale as necessary to accommodate more."
-              apps={apps}
-              setApps={setApps}
-            />
-            <UsersControl
-              users={users}
-              setUsers={setUsers}
-            />
-            <div className="hint">
-              *Accounts requiring {'>'}6 clusters or {'>'}60 users should reach out
-              to discuss our Enterprise option to optimize plan costs to your specific needs.
+      <PricingCalculatorContainerQuery>
+        <PricingCalculatorWrap>
+          <div className="content">
+            <div className="column">
+              <ProviderControl
+                header="What cloud provider will you use?"
+                providerId={providerId}
+                setProviderId={setProviderId}
+              />
+              <ClustersControl
+                clusters={clusters}
+                setClusters={setClusters}
+              />
+              <AppsControl
+                header="How many applications do you plan to install?"
+                caption="The default deployment includes headroom for a few applications, but will scale as necessary to accommodate more."
+                apps={apps}
+                setApps={setApps}
+              />
+              <UsersControl
+                users={users}
+                setUsers={setUsers}
+              />
+              <div className="hint">
+                *Accounts requiring {'>'}6 clusters or {'>'}60 users should reach out
+                to discuss our Enterprise option to optimize plan costs to your specific needs.
+              </div>
+            </div>
+            <div className="column">
+              <Switch
+                disabled={users > 5}
+                checked={professional}
+                onChange={({ target: { checked } }) => setProfessional(checked)}
+                marginBottom="xlarge"
+              >
+                Professional plan
+              </Switch>
+              <Costs header="Cloud costs">
+                <Cost
+                  cost={providerCost?.k8s}
+                  label={`${provider?.name} Kubernetes cost`}
+                  tooltip="Cost to deploy this provider's managed version of Kubernetes."
+                />
+                <Cost
+                  cost={providerCost?.infra}
+                  label={`${provider?.name} infrastructure price`}
+                  tooltip="Cost to provision and run standard instances on this provider."
+                />
+                <Cost
+                  cost={providerCost?.app}
+                  label="Application infrastructure"
+                  tooltip="Cost to deploy and run selected number of applications. Default setup includes headroom for a few applications and will scale to meet additional needs."
+                />
+              </Costs>
+              <Costs
+                header="Plural costs"
+                marginTop={48}
+              >
+                <Cost
+                  cost={pluralCost?.clusters}
+                  label={`for ${clusters} clusters`}
+                />
+                <Cost
+                  cost={pluralCost?.users}
+                  label={`for ${users} users`}
+                />
+              </Costs>
+              <TotalCost
+                providerCost={providerCost?.total}
+                provider={provider?.name}
+                proPlan={professional}
+                pluralCost={pluralCost?.total}
+              />
             </div>
           </div>
-          <div className="column">
-            <Switch
-              disabled={users > 5}
-              checked={professional}
-              onChange={({ target: { checked } }) => setProfessional(checked)}
-              marginBottom="xlarge"
-            >
-              Professional plan
-            </Switch>
-            <Costs header="Cloud costs">
-              <Cost
-                cost={providerCost?.k8s}
-                label={`${provider?.name} Kubernetes cost`}
-                tooltip="Cost to deploy this provider's managed version of Kubernetes."
-              />
-              <Cost
-                cost={providerCost?.infra}
-                label={`${provider?.name} infrastructure price`}
-                tooltip="Cost to provision and run standard instances on this provider."
-              />
-              <Cost
-                cost={providerCost?.app}
-                label="Application infrastructure"
-                tooltip="Cost to deploy and run selected number of applications. Default setup includes headroom for a few applications and will scale to meet additional needs."
-              />
-            </Costs>
-            <Costs
-              header="Plural costs"
-              marginTop={48}
-            >
-              <Cost
-                cost={pluralCost?.clusters}
-                label={`for ${clusters} clusters`}
-              />
-              <Cost
-                cost={pluralCost?.users}
-                label={`for ${users} users`}
-              />
-            </Costs>
-            <TotalCost
-              providerCost={providerCost?.total}
-              provider={provider?.name}
-              proPlan={professional}
-              pluralCost={pluralCost?.total}
-            />
-          </div>
-        </div>
-      </PricingCalculatorWrap>
+        </PricingCalculatorWrap>
+      </PricingCalculatorContainerQuery>
     </Card>
   )
 })

--- a/src/components/pricingcalculator/misc.tsx
+++ b/src/components/pricingcalculator/misc.tsx
@@ -1,5 +1,6 @@
 import { ComponentType } from 'react'
 import styled from 'styled-components'
+import styledContainerQuery from 'styled-container-query'
 
 import AwsLogoIcon from '../icons/AwsLogoIcon'
 import AzureLogoIcon from '../icons/AzureLogoIcon'
@@ -108,11 +109,6 @@ export const PricingCalculatorWrap = styled.div(({ theme }) => ({
     flexShrink: 1,
     gap: theme.spacing.xxxlarge,
 
-    '@media (max-width: 780px)': {
-      flexDirection: 'column',
-      gap: theme.spacing.xlarge,
-    },
-
     '&.with-padding': {
       paddingBottom: theme.spacing.medium,
     },
@@ -131,9 +127,20 @@ export const PricingCalculatorWrap = styled.div(({ theme }) => ({
     color: theme.colors['text-xlight'],
     marginBottom: theme.spacing.medium,
     fontStyle: 'italic',
-
-    '@media (max-width: 780px)': {
-      marginBottom: 0,
-    },
   },
 }))
+
+// If https://github.com/styled-components/styled-components/issues/416
+// will be fixed then we can remove it and use above wrapper.
+export const PricingCalculatorContainerQuery = styledContainerQuery.div`
+  &:container(max-width: 620px) {
+    .content {
+      flex-direction: column !important;
+      gap: 32px;
+    }
+
+    .hint {
+      marginBottom: 0;
+    }
+},
+`

--- a/src/components/pricingcalculator/misc.tsx
+++ b/src/components/pricingcalculator/misc.tsx
@@ -135,12 +135,12 @@ export const PricingCalculatorWrap = styled.div(({ theme }) => ({
 export const PricingCalculatorContainerQuery = styledContainerQuery.div`
   &:container(max-width: 620px) {
     .content {
-      flex-direction: column !important;
+      flex-direction: column;
       gap: 32px;
     }
 
     .hint {
-      marginBottom: 0;
+      margin-bottom: 0;
     }
 },
 `

--- a/src/components/pricingcalculator/misc.tsx
+++ b/src/components/pricingcalculator/misc.tsx
@@ -1,5 +1,7 @@
 import { ComponentType } from 'react'
 import styled from 'styled-components'
+
+// @ts-ignore
 import styledContainerQuery from 'styled-container-query'
 
 import AwsLogoIcon from '../icons/AwsLogoIcon'

--- a/yarn.lock
+++ b/yarn.lock
@@ -2658,6 +2658,7 @@ __metadata:
     rimraf: 3.0.2
     storybook: 7.0.0-alpha.54
     styled-components: 5.3.6
+    styled-container-query: 1.3.5
     typescript: 4.9.5
     use-immer: 0.8.1
     vite: 4.1.1
@@ -7141,7 +7142,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"classnames@npm:2.3.2":
+"classnames@npm:2.3.2, classnames@npm:^2.2.6":
   version: 2.3.2
   resolution: "classnames@npm:2.3.2"
   checksum: 2c62199789618d95545c872787137262e741f9db13328e216b093eea91c85ef2bfb152c1f9e63027204e2559a006a92eb74147d46c800a9f96297ae1d9f96f4e
@@ -10895,7 +10896,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hoist-non-react-statics@npm:^3.0.0, hoist-non-react-statics@npm:^3.2.0, hoist-non-react-statics@npm:^3.3.0, hoist-non-react-statics@npm:^3.3.1":
+"hoist-non-react-statics@npm:^3.0.0, hoist-non-react-statics@npm:^3.2.0, hoist-non-react-statics@npm:^3.3.0, hoist-non-react-statics@npm:^3.3.1, hoist-non-react-statics@npm:^3.3.2":
   version: 3.3.2
   resolution: "hoist-non-react-statics@npm:3.3.2"
   dependencies:
@@ -15536,6 +15537,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"resize-observer@npm:^1.0.0":
+  version: 1.0.4
+  resolution: "resize-observer@npm:1.0.4"
+  checksum: 43e2f45e40507279cad474f6bd2fe62e92de1fd1d67cd5285ece1fec6c1b664c4d3795b094b2be292244bf542b1b5402578670400beadc2cfedac8fb483a0976
+  languageName: node
+  linkType: hard
+
 "resolve-alpn@npm:^1.2.0":
   version: 1.2.1
   resolution: "resolve-alpn@npm:1.2.1"
@@ -16036,6 +16044,13 @@ __metadata:
   bin:
     shjs: bin/shjs
   checksum: 7babc46f732a98f4c054ec1f048b55b9149b98aa2da32f6cf9844c434b43c6251efebd6eec120937bd0999e13811ebd45efe17410edb3ca938f82f9381302748
+  languageName: node
+  linkType: hard
+
+"shorthash@npm:0.0.2":
+  version: 0.0.2
+  resolution: "shorthash@npm:0.0.2"
+  checksum: 4048833f2a7f324350cc1a48a6b64bca268e5a2e9c59cb6cad3607c41fd800bf1739498fe4b8b6737709cdb540fb74125fb7254eba98bdd3dc41e8d9f7990b20
   languageName: node
   linkType: hard
 
@@ -16557,6 +16572,22 @@ __metadata:
     react-dom: ">= 16.8.0"
     react-is: ">= 16.8.0"
   checksum: 68eac1e451be81d66739cf86de8ec9e72f46e7584aa359271761a2437468210bd7cf0a864281fc97dab08c32b35e6bf7513dc8b4104ed6b196cf8d65674dd289
+  languageName: node
+  linkType: hard
+
+"styled-container-query@npm:1.3.5":
+  version: 1.3.5
+  resolution: "styled-container-query@npm:1.3.5"
+  dependencies:
+    classnames: ^2.2.6
+    hoist-non-react-statics: ^3.3.2
+    resize-observer: ^1.0.0
+    shorthash: 0.0.2
+  peerDependencies:
+    react: ^16.9.0
+    react-dom: ^16.9.0
+    styled-components: ^4.3.2
+  checksum: 4bc8e046234ce39b33df199603bf4a3887abb5239966d5b3904b45b79889385320bd0df7129a0805c945947aa692ca6b950296d041ee68b6b667f912926c3b77
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Relying on container size is safer/more flexible option than using media queries.

Unfortunately styled-components do not support it and I had to use additional library. See: https://github.com/styled-components/styled-components/issues/416.