### PR TITLE
feat: Allow usage of custom onCopy method for codeline

### DIFF
--- a/src/components/Codeline.tsx
+++ b/src/components/Codeline.tsx
@@ -1,4 +1,4 @@
-import { Ref, forwardRef, useEffect, useState } from 'react'
+import { Ref, forwardRef, useCallback, useEffect, useState } from 'react'
 import { CssProps, Div, Flex, FlexProps } from 'honorable'
 import { useTheme } from 'styled-components'
 
@@ -8,16 +8,29 @@ import CopyIcon from './icons/CopyIcon'
 
 type CodelineProps = FlexProps & {
   displayText?: string
+  onCopy: (text: string) => Promise<void>
 }
 
 const propTypes = {}
 
 function CodelineRef(
-  { children, displayText, ...props }: CodelineProps,
+  { children, displayText, onCopy, ...props }: CodelineProps,
   ref: Ref<any>
 ) {
   const [copied, setCopied] = useState(false)
   const theme = useTheme()
+
+  const handleCopy = useCallback(() => {
+    if (onCopy) {
+      onCopy(children as string).then(() => setCopied(true))
+
+      return
+    }
+
+    window.navigator.clipboard
+      .writeText(children as string)
+      .then(() => setCopied(true))
+  }, [children, onCopy])
 
   useEffect(() => {
     if (copied) {
@@ -26,11 +39,6 @@ function CodelineRef(
       return () => clearTimeout(timeout)
     }
   }, [copied])
-
-  const handleCopy = () =>
-    window.navigator.clipboard
-      .writeText(children as string)
-      .then(() => setCopied(true))
 
   return (
     <Flex

--- a/src/stories/Codeline.stories.tsx
+++ b/src/stories/Codeline.stories.tsx
@@ -26,8 +26,34 @@ function Template(args: any) {
   )
 }
 
+function CustomCopyTemplate(args: any) {
+  const onCopy = (text: string): Promise<void> =>
+    window.navigator.clipboard.writeText(text)
+
+  return (
+    <Flex
+      direction="column"
+      gap="medium"
+    >
+      <span>
+        This codeline copy uses a custom onCopy function that returns a promise!
+      </span>
+      <Codeline
+        onCopy={onCopy}
+        {...args}
+      />
+    </Flex>
+  )
+}
+
 export const Default = Template.bind({})
 
 Default.args = {
+  children: 'npm i @pluralsh/design-system',
+}
+
+export const CustomCopy = CustomCopyTemplate.bind({})
+
+CustomCopy.args = {
   children: 'npm i @pluralsh/design-system',
 }


### PR DESCRIPTION
Required by the CLI UI since it does not support `window.navigator.clipboard` and requires some custom logic to handle clipboard copy.