### PR TITLE
feat: Multicluster components

### DIFF
--- a/src/components/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs.tsx
@@ -9,10 +9,11 @@ import React, {
   useRef,
   useState,
 } from 'react'
-import { Div, Flex, FlexProps } from 'honorable'
-import styled from 'styled-components'
+import { Flex, FlexProps, Nav, Ol } from 'honorable'
+import styled, { useTheme } from 'styled-components'
 import classNames from 'classnames'
 import { SwitchTransition, Transition } from 'react-transition-group'
+import { useVisuallyHidden } from '@react-aria/visually-hidden'
 
 import useResizeObserver from '../hooks/useResizeObserver'
 import usePrevious from '../hooks/usePrevious'
@@ -33,7 +34,12 @@ function getCrumbKey(crumb: Breadcrumb) {
 }
 
 const CrumbSeparator = styled(({ className }: { className?: string }) => (
-  <div className={className}>/</div>
+  <div
+    className={className}
+    aria-hidden
+  >
+    /
+  </div>
 ))(({ theme }) => ({
   ...theme.partials.text.caption,
   color: theme.colors['text-input-disabled'],
@@ -62,7 +68,8 @@ function CrumbLink({
   )
 }
 
-const CrumbLinkWrap = styled.div(({ theme }) => ({
+const CrumbLinkWrap = styled.li(({ theme }) => ({
+  ...theme.partials.reset.li,
   display: 'flex',
   flexDirection: 'row',
   gap: theme.spacing.small,
@@ -163,21 +170,25 @@ function CrumbListRef(
     breadcrumbs,
     maxLength,
     visibleListId,
+    ariaOnly = false,
     ...props
   }: {
     breadcrumbs: Breadcrumb[]
     maxLength: number
-    visibleListId: string
+    visibleListId?: string
+    ariaOnly?: boolean
   } & FlexProps,
   ref: MutableRefObject<HTMLDivElement>
 ) {
   const id = useId()
+  const { visuallyHiddenProps } = useVisuallyHidden()
+  const theme = useTheme()
 
   if (breadcrumbs?.length < 1) {
     return null
   }
   maxLength = Math.min(maxLength, breadcrumbs.length)
-  const hidden = visibleListId !== id
+  const heightlessHidden = visibleListId !== id
 
   const head = maxLength > 1 ? [breadcrumbs[0]] : []
   const middle = breadcrumbs.slice(
@@ -189,18 +200,23 @@ function CrumbListRef(
     breadcrumbs.length
   )
 
+  console.log('ariaOnly', ariaOnly, visuallyHiddenProps)
+
   return (
-    <Flex
+    <Ol
       id={id}
       ref={ref}
-      {...(hidden
-        ? { height: 0, opacity: 0, overflow: 'hidden', 'aria-visible': 'false' }
+      {...(heightlessHidden && !ariaOnly
+        ? { height: 0, opacity: 0, overflow: 'hidden' }
         : {})}
-      className="crumbList"
+      display="flex"
+      {...theme.partials.reset.list}
+      className={ariaOnly ? '' : 'crumbList'}
       direction="row"
       gap="small"
       maxWidth="max-content"
       {...props}
+      {...(ariaOnly ? visuallyHiddenProps : {})}
     >
       {head.map((headCrumb) => (
         <CrumbLink
@@ -223,7 +239,7 @@ function CrumbListRef(
           isLast={i === tail.length - 1}
         />
       ))}
-    </Flex>
+    </Ol>
   )
 }
 
@@ -243,13 +259,12 @@ type BreadcrumbsProps = {
   breadcrumbs?: Breadcrumb[]
 } & FlexProps
 
-export function BreadcrumbsInside({
+export function DynamicBreadcrumbs({
   minLength = 0,
   maxLength = Infinity,
   collapsible = true,
   breadcrumbs,
   wrapperRef: transitionRef,
-  ...props
 }: BreadcrumbsProps & {
   breadcrumbs: Breadcrumb[]
   wrapperRef?: MutableRefObject<HTMLDivElement>
@@ -324,12 +339,14 @@ export function BreadcrumbsInside({
 
   return (
     <Flex
+      // Hide dynamic breadcrumb list from screen readers.
+      // A screen reader-only list is provided in root component.
+      aria-hidden
       direction="column"
       ref={(elt: any) => {
         wrapperRef.current = elt
         if (transitionRef) transitionRef.current = elt
       }}
-      {...props}
     >
       {children}
     </Flex>
@@ -359,18 +376,25 @@ export function Breadcrumbs({
   }
 
   return (
-    <Div {...props}>
+    <Nav
+      aria-label="breadcrumbs"
+      {...props}
+    >
+      {/* Prevent flashing by swapping in new hidden component every time breadcrumbs
+      change and waiting for refit before making visible and removing old breadcrumbs */}
       <SwitchTransition mode="in-out">
         <Transition
           key={String(transitionKey.current)}
           timeout={200}
+          // Typing for 'addEndListener' on <Transition> component is incorrect
+          // when not providing 'ref' prop
           // @ts-expect-error
           addEndListener={(node, done) => {
             node?.addEventListener('refitdone', done, false)
           }}
         >
           {(state) => (
-            <BreadcrumbsInside
+            <DynamicBreadcrumbs
               minLength={minLength}
               maxLength={maxLength}
               collapsible={collapsible}
@@ -380,6 +404,12 @@ export function Breadcrumbs({
           )}
         </Transition>
       </SwitchTransition>
-    </Div>
+      {/* Provide stable, but visually hidden crumb list for screen readers */}
+      <CrumbList
+        ariaOnly
+        breadcrumbs={breadcrumbs}
+        maxLength={Infinity}
+      />
+    </Nav>
   )
 }

--- a/src/components/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs.tsx
@@ -171,13 +171,12 @@ function CrumbListRef(
     maxLength,
     visibleListId,
     ariaOnly = false,
-    ...props
   }: {
     breadcrumbs: Breadcrumb[]
     maxLength: number
     visibleListId?: string
     ariaOnly?: boolean
-  } & FlexProps,
+  },
   ref: MutableRefObject<HTMLDivElement>
 ) {
   const id = useId()
@@ -206,16 +205,15 @@ function CrumbListRef(
     <Ol
       id={id}
       ref={ref}
-      {...(heightlessHidden && !ariaOnly
-        ? { height: 0, opacity: 0, overflow: 'hidden' }
-        : {})}
       display="flex"
       {...theme.partials.reset.list}
       className={ariaOnly ? '' : 'crumbList'}
       direction="row"
       gap="small"
       maxWidth="max-content"
-      {...props}
+      {...(heightlessHidden && !ariaOnly
+        ? { height: 0, opacity: 0, overflow: 'hidden' }
+        : {})}
       {...(ariaOnly ? visuallyHiddenProps : {})}
     >
       {head.map((headCrumb) => (

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -1,10 +1,15 @@
 import { ExtendTheme, Input as HonorableInput, mergeTheme } from 'honorable'
 import type { InputProps as HonorableInputProps } from 'honorable'
-import { ReactNode, forwardRef } from 'react'
+import { ReactNode, forwardRef, useMemo } from 'react'
+import { useTheme } from 'styled-components'
+
+import { useFillLevel } from './contexts/FillLevelContext'
+import { titleContentStyles } from './Select'
 
 export type InputProps = HonorableInputProps & {
   suffix?: ReactNode
   prefix?: ReactNode
+  titleContent?: ReactNode
 }
 
 const prefixSuffixIconStyle = {
@@ -14,8 +19,26 @@ const prefixSuffixIconStyle = {
 }
 
 const Input = forwardRef(
-  ({ startIcon, endIcon, suffix, prefix, ...props }: InputProps, ref) => {
+  (
+    { startIcon, endIcon, suffix, prefix, titleContent, ...props }: InputProps,
+    ref
+  ) => {
     let themeExtension: any = {}
+    const theme = useTheme()
+    const parentFillLevel = useFillLevel()
+    const size = (props as any).large
+      ? 'large'
+      : (props as any).small
+      ? 'small'
+      : 'medium'
+
+    const titleContentIconStyle = useMemo(
+      () => ({
+        ...titleContentStyles({ theme, parentFillLevel, size }),
+        alignSelf: 'stretch',
+      }),
+      [parentFillLevel, theme, size]
+    )
 
     if (suffix) {
       themeExtension = mergeTheme(themeExtension, {
@@ -33,13 +56,21 @@ const Input = forwardRef(
         },
       })
     }
+    if (titleContent) {
+      themeExtension = mergeTheme(themeExtension, {
+        Input: {
+          Root: [{ paddingLeft: 0 }],
+          StartIcon: [titleContentIconStyle],
+        },
+      })
+    }
 
     return (
       <ExtendTheme theme={themeExtension}>
         <HonorableInput
           ref={ref}
           endIcon={suffix || endIcon}
-          startIcon={prefix || startIcon}
+          startIcon={titleContent || prefix || startIcon}
           {...props}
         />
       </ExtendTheme>

--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -95,6 +95,35 @@ function Trigger({ buttonElt, isOpen, ...props }: TriggerProps) {
   })
 }
 
+export const titleContentStyles = ({
+  theme,
+  parentFillLevel,
+  size = 'medium',
+}: {
+  theme: any
+  parentFillLevel: FillLevel
+  size?: Size
+}) => {
+  const hPad = theme.spacing.small
+  const vPad = size === 'small' ? 5 : 9
+
+  return {
+    ...theme.partials.text.caption,
+    alignItems: 'center',
+    backgroundColor:
+      theme.colors[parentFillLevel < 2 ? 'fill-three' : 'fill-three-selected'],
+    color: theme.colors.text,
+    display: 'flex',
+    flexDirection: 'row',
+    fontWeight: 600,
+    // Must specify individual padding to override Honorable styles on <Input>
+    paddingTop: vPad,
+    paddingBottom: vPad,
+    paddingLeft: hPad,
+    paddingRight: hPad,
+  }
+}
+
 const SelectButtonInner = styled.div<{
   $isOpen: boolean
   $size: Size
@@ -116,19 +145,11 @@ const SelectButtonInner = styled.div<{
     color: theme.colors['text-light'],
     border: theme.borders.input,
     borderRadius: theme.borderRadiuses.medium,
-    '.titleContent': {
-      ...theme.partials.text.caption,
-      alignItems: 'center',
-      backgroundColor:
-        theme.colors[
-          parentFillLevel < 2 ? 'fill-three' : 'fill-three-selected'
-        ],
-      color: theme.colors.text,
-      display: 'flex',
-      flexDirection: 'row',
-      fontWeight: 600,
-      padding: `${size === 'medium' ? 9 : 5}px ${theme.spacing.small}px`,
-    },
+    '.titleContent': titleContentStyles({
+      theme,
+      size,
+      parentFillLevel,
+    }),
     '.content': {
       alignItems: 'center',
       display: 'flex',

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -2,6 +2,7 @@ import { Div, DivProps } from 'honorable'
 import {
   CSSProperties,
   ComponentProps,
+  Fragment,
   MouseEvent,
   MutableRefObject,
   Ref,
@@ -618,7 +619,7 @@ function TableRef(
               const i = row.index
 
               return (
-                <>
+                <Fragment key={row.id}>
                   <Tr
                     key={row.id}
                     onClick={(e) => onRowClick?.(e, row)}
@@ -654,7 +655,7 @@ function TableRef(
                       </TdExpand>
                     </Tr>
                   )}
-                </>
+                </Fragment>
               )
             })}
             {paddingBottom > 0 && (

--- a/src/stories/Input.stories.tsx
+++ b/src/stories/Input.stories.tsx
@@ -1,6 +1,7 @@
 import { Div, Flex } from 'honorable'
 
 import MagnifyingGlassIcon from '../components/icons/MagnifyingGlassIcon'
+import BrowseAppsIcon from '../components/icons/BrowseAppsIcon'
 import CaretDownIcon from '../components/icons/CaretDownIcon'
 import Input from '../components/Input'
 
@@ -98,4 +99,15 @@ export const Multiline = CustomInputTemplate.bind({})
 Multiline.args = {
   multiline: true,
   minRows: 3,
+}
+
+export const TitleContent = CustomInputTemplate.bind({})
+
+TitleContent.args = {
+  titleContent: (
+    <>
+      <BrowseAppsIcon marginRight="small" />
+      Marketplace
+    </>
+  ),
 }

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -507,6 +507,7 @@ const honorableTheme = mergeTheme(defaultTheme, {
       {
         body2: true,
         display: 'flex',
+        overflow: 'hidden',
         justifyContent: 'space-between',
         align: 'center',
         height: 'auto',

--- a/src/theme/resets.ts
+++ b/src/theme/resets.ts
@@ -11,4 +11,13 @@ export const resetPartials = {
     cursor: 'pointer',
     outline: 'inherit',
   },
+  list: {
+    margin: 0,
+    padding: 0,
+    listStyle: 'none',
+  },
+  li: {
+    margin: 0,
+    padding: 0,
+  },
 } as const satisfies Record<string, CSSObject>


### PR DESCRIPTION
- Add `<Input>` `titleContent` variant for use on Marketplace page
- Fix focus styling on `<Input>` that have `prefix`, `suffix` or `titleContent`
- Make `<Breadcrumbs>` more accessible
- Fix react `key` warning in `<Table>`