### PR TITLE
fix: CSS variables out of sync in styled-components

### DIFF
--- a/src/theme/focus.ts
+++ b/src/theme/focus.ts
@@ -16,12 +16,12 @@ export const getFocusPartials = ({ mode }: { mode: ColorMode }) => {
       boxShadow: boxShadows.focused,
     },
     outline: {
-      '--outlineC': semanticColorCssVars['border-outline-focused'],
-      outline: `${borderWidths.focus}px solid var(--outlineC)`,
+      '--outline-c': semanticColorCssVars['border-outline-focused'],
+      outline: `${borderWidths.focus}px solid var(--outline-c)`,
     },
     button: {
-      '--outlineC': semanticColorCssVars['border-outline-focused'],
-      outline: `1px solid var(--outlineC)}`,
+      '--outline-c': semanticColorCssVars['border-outline-focused'],
+      outline: `1px solid var(--outline-c)}`,
       outlineOffset: '-1px',
     },
     insetAbsolute: {

--- a/src/theme/text.ts
+++ b/src/theme/text.ts
@@ -156,16 +156,16 @@ const textPartials = {
     textOverflow: 'ellipsis',
   },
   inlineLink: {
-    '--inlineLinkC': semanticColorCssVars['action-link-inline'],
-    color: `var(--inlineLinkC)`,
+    '--inline-link-c': semanticColorCssVars['action-link-inline'],
+    color: `var(--inline-link-c)`,
     textDecoration: 'underline',
     '&:hover': {
-      '--inlineLinkC': semanticColorCssVars['action-link-inline-hover'],
+      '--inline-link-c': semanticColorCssVars['action-link-inline-hover'],
     },
     '&:visited, &:active': {
-      '--inlineLinkC': semanticColorCssVars['action-link-inline-visited'],
+      '--inline-link-c': semanticColorCssVars['action-link-inline-visited'],
       '&:hover': {
-        '--inlineLinkC':
+        '--inline-link-c':
           semanticColorCssVars['action-link-inline-visited-hover'],
       },
     },


### PR DESCRIPTION
styled-components will auto-convert to kebab-case when declaring a var, but not when referencing the var, so css vars were getting out of sync. Changed all css vars to kebab-case to avoid this.