### PR TITLE
fix: Styles not applied for :visited and :active inline links

### DIFF
--- a/src/stories/A.stories.tsx
+++ b/src/stories/A.stories.tsx
@@ -8,7 +8,10 @@ export default {
 function Template(args: any) {
   return (
     <Flex gap="medium">
-      <A {...args} />
+      <A
+        href="#"
+        {...args}
+      />
       <A
         href="https://github.com"
         {...args}
@@ -16,6 +19,7 @@ function Template(args: any) {
         Github
       </A>
       <A
+        href="#"
         inline
         {...args}
       >

--- a/src/theme/marketingText.ts
+++ b/src/theme/marketingText.ts
@@ -102,6 +102,9 @@ const marketingTextPartials = {
     },
     '&:visited, &:active': {
       color: semanticColorCssVars['action-link-inline-visited'],
+      '&:hover': {
+        color: semanticColorCssVars['action-link-inline-visited-hover'],
+      },
     },
   },
   navLink: {

--- a/src/theme/text.ts
+++ b/src/theme/text.ts
@@ -156,17 +156,23 @@ const textPartials = {
     textOverflow: 'ellipsis',
   },
   inlineLink: {
+    // Intermediate variables needed to avoid mangling by Honorable
+    // Must declare all intermediate color variables at style root due to
+    // security restritions on setting properties for :visited pseudo-class
     '--inline-link-c': semanticColorCssVars['action-link-inline'],
+    '--inline-link-c-h': semanticColorCssVars['action-link-inline-hover'],
+    '--inline-link-c-v': semanticColorCssVars['action-link-inline-visited'],
+    '--inline-link-c-v-h':
+      semanticColorCssVars['action-link-inline-visited-hover'],
     color: `var(--inline-link-c)`,
     textDecoration: 'underline',
     '&:hover': {
-      '--inline-link-c': semanticColorCssVars['action-link-inline-hover'],
+      color: 'var(--inline-link-c-h)',
     },
     '&:visited, &:active': {
-      '--inline-link-c': semanticColorCssVars['action-link-inline-visited'],
+      color: 'var(--inline-link-c-v)',
       '&:hover': {
-        '--inline-link-c':
-          semanticColorCssVars['action-link-inline-visited-hover'],
+        color: 'var(--inline-link-c-v-h)',
       },
     },
   },


### PR DESCRIPTION
Visited links weren't getting their colors applied due to security restrictions against setting css variables in `:visited` pseudo-classes. This sets the intermediate variables needed to avoid mangling by Honorable outside the pseudo classes, so we can set the `color` property directly in the pseudo-classes (which is one of the few properties allowed to be set within `:visited`).

Also added `:hover` styles for marketing inlineLinks. Intermediate css variables aren't needed there since we don't use marketing text styles with Honorable.