### PR TITLE
fix: Broken dropdowns

### DIFF
--- a/src/components/PopoverListBox.tsx
+++ b/src/components/PopoverListBox.tsx
@@ -49,7 +49,7 @@ export const PopoverWrapper = styled.div<{
 }))
 
 const Animated = styled(animated.div)((_) => ({
-  maxWidth: '100%',
+  width: '100%',
   maxHeight: '100%',
   display: 'flex',
 }))


### PR DESCRIPTION
Accidentally included a change in the Datepicker PR that was causing dropdowns to be sized incorrectly. This reverts that change.