### PR TITLE
feat: Improve Switch styling and enable `css` prop

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,18 +1,13 @@
-import { type StorybookConfig } from '@storybook/builder-vite'
-import { mergeConfig } from 'vite'
-
-import viteConfig from '../vite.config'
+import { type StorybookConfig } from '@storybook/react-vite'
 
 const config: StorybookConfig = {
   stories: ['../src/**/*.stories.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],
-  addons: ['@storybook/addon-links', '@storybook/addon-essentials', '@storybook/addon-interactions'],
-  framework: {
-    name: '@storybook/react-vite',
-  },
-  core: {
-    builder: '@storybook/builder-vite',
-  },
-  viteFinal: async config => (mergeConfig(config, viteConfig)),
+  addons: [
+    '@storybook/addon-links',
+    '@storybook/addon-essentials',
+    '@storybook/addon-interactions',
+  ],
+  framework: '@storybook/react-vite',
 }
 
 export default config

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@tanstack/react-virtual": "3.0.0-beta.54",
     "@types/chroma-js": "2.4.0",
     "@types/lodash-es": "4.17.8",
+    "babel-plugin-styled-components": "2.1.4",
     "chroma-js": "2.4.2",
     "classnames": "2.3.2",
     "grommet": "2.32.2",
@@ -119,7 +120,7 @@
     "rimraf": "5.0.1",
     "storybook": "7.4.0",
     "styled-components": "5.3.11",
-    "typescript": "4.9.5",
+    "typescript": "5.2.2",
     "vite": "4.4.9",
     "vitest": "0.34.3"
   },

--- a/src/components/Accordion.tsx
+++ b/src/components/Accordion.tsx
@@ -134,7 +134,6 @@ function AccordionContentUnstyled({
   const mOffset = theme.spacing.medium - theme.spacing.small
 
   return (
-    // @ts-ignore
     <AnimatedDiv
       style={
         {

--- a/src/components/Accordion.tsx
+++ b/src/components/Accordion.tsx
@@ -10,7 +10,7 @@ import {
   useState,
 } from 'react'
 import React from 'react'
-import { animated, useSpring } from 'react-spring'
+import { useSpring } from 'react-spring'
 import styled, { useTheme } from 'styled-components'
 
 import useResizeObserver from '../hooks/useResizeObserver'
@@ -18,6 +18,7 @@ import { type UseDisclosureProps, useDisclosure } from '../hooks/useDisclosure'
 import { CaretDownIcon } from '../icons'
 
 import Card from './Card'
+import { AnimatedDiv } from './AnimatedDiv'
 
 const paddingTransition = '0.2s ease'
 
@@ -133,17 +134,20 @@ function AccordionContentUnstyled({
   const mOffset = theme.spacing.medium - theme.spacing.small
 
   return (
-    <animated.div
-      style={{
-        overflow: 'hidden',
-        ...(!_unstyled
-          ? {
-              marginTop: -mOffset,
-              marginBottom: isOpen ? 0 : mOffset,
-            }
-          : {}),
-        ...springs,
-      }}
+    // @ts-ignore
+    <AnimatedDiv
+      style={
+        {
+          overflow: 'hidden',
+          ...(!_unstyled
+            ? {
+                marginTop: -mOffset,
+                marginBottom: isOpen ? 0 : mOffset,
+              }
+            : {}),
+          ...springs,
+        } as any
+      }
     >
       <div
         className={className}
@@ -152,7 +156,7 @@ function AccordionContentUnstyled({
       >
         {children}
       </div>
-    </animated.div>
+    </AnimatedDiv>
   )
 }
 const AccordionContent = styled(AccordionContentUnstyled)(

--- a/src/components/AnimatedDiv.tsx
+++ b/src/components/AnimatedDiv.tsx
@@ -1,0 +1,6 @@
+// Workaround for issue with styled components `css` prop and `animated.div`
+// https://github.com/pmndrs/react-spring/issues/1515
+import { animated } from 'react-spring'
+import styled from 'styled-components'
+
+export const AnimatedDiv = styled(animated.div)<any>``

--- a/src/components/Layer.tsx
+++ b/src/components/Layer.tsx
@@ -9,11 +9,13 @@ import {
   useState,
 } from 'react'
 import { createPortal } from 'react-dom'
-import { type UseTransitionProps, animated, useTransition } from 'react-spring'
+import { type UseTransitionProps, useTransition } from 'react-spring'
 import { isNil } from 'lodash-es'
 import styled, { useTheme } from 'styled-components'
 
 import usePrevious from '../hooks/usePrevious'
+
+import { AnimatedDiv } from './AnimatedDiv'
 
 const DIRECTIONS = ['up', 'down', 'left', 'right'] as const
 
@@ -290,13 +292,13 @@ function LayerRef(
       margin={margin}
     >
       {transitions((styles) => (
-        <animated.div
+        <AnimatedDiv
           className="animated"
           ref={finalRef}
           style={{ ...styles }}
         >
           {children}
-        </animated.div>
+        </AnimatedDiv>
       ))}
     </LayerWrapper>
   )

--- a/src/components/PopoverCornerScale.tsx
+++ b/src/components/PopoverCornerScale.tsx
@@ -14,7 +14,7 @@ import { Popover, type PopoverProps } from './ReactAriaPopover'
 type PopoverCornerScaleProps = {
   floating: UseFloatingReturn<any>
   children: ReactNode
-} & Pick<PopoverProps, 'isOpen' | 'onClose' | 'popoverRef'> // &
+} & Pick<PopoverProps, 'isOpen' | 'onClose' | 'popoverRef'>
 
 export const PopoverWrapper = styled.div<{
   $isOpen: boolean
@@ -29,7 +29,7 @@ export const PopoverWrapper = styled.div<{
   },
 }))
 
-const Animated = styled(animated.div)((_) => ({
+const Animated = styled(animated.div)<any>((_) => ({
   display: 'flex',
 }))
 

--- a/src/components/PopoverListBox.tsx
+++ b/src/components/PopoverListBox.tsx
@@ -48,7 +48,7 @@ export const PopoverWrapper = styled.div<{
   },
 }))
 
-const Animated = styled(animated.div)((_) => ({
+const Animated = styled(animated.div)<any>((_) => ({
   width: '100%',
   maxHeight: '100%',
   display: 'flex',

--- a/src/components/Switch.tsx
+++ b/src/components/Switch.tsx
@@ -45,9 +45,6 @@ const SwitchSC = styled.label<SwitchStyleProps>(
               backgroundColor: $checked
                 ? theme.colors['action-primary-hover']
                 : theme.colors['action-input-hover'],
-              borderColor: $checked
-                ? theme.colors['action-primary-hover']
-                : theme.colors['action-input-hover'],
             },
             [SwitchHandleSC]: {
               backgroundColor: $checked
@@ -81,7 +78,7 @@ const SwitchToggleSC = styled.div<SwitchStyleProps>(
         : $focused
         ? theme.colors['border-outline-focused']
         : $checked
-        ? theme.colors['action-primary']
+        ? 'transparent'
         : theme.colors['border-input'],
     transition: 'all 0.15s ease',
   })

--- a/src/components/Switch.tsx
+++ b/src/components/Switch.tsx
@@ -1,77 +1,93 @@
-import { useRef } from 'react'
+import { useMemo, useRef } from 'react'
 import { useToggleState } from 'react-stately'
 import {
   type AriaSwitchProps,
   VisuallyHidden,
+  useSwitch as useAriaSwitch,
   useFocusRing,
-  useSwitch,
 } from 'react-aria'
 import styled from 'styled-components'
 
-const SwitchSC = styled.label<{
+export type SwitchStyleProps = {
   $checked: boolean
   $disabled: boolean
   $readOnly: boolean
-}>(({ $checked, $disabled, $readOnly, theme }) => ({
-  display: 'flex',
-  columnGap: theme.spacing.xsmall,
-  alignItems: 'center',
-  ...theme.partials.text.body2,
-  cursor: $disabled ? 'not-allowed' : $readOnly ? 'default' : 'pointer',
-  color: theme.colors['text-light'],
-  ...($disabled || $readOnly
-    ? {}
-    : {
-        '&:hover': {
-          color: theme.colors.text,
-          [SwitchToggleSC]: {
-            backgroundColor: $checked
-              ? theme.colors['action-primary-hover']
-              : theme.colors['action-input-hover'],
-            borderColor: $checked
-              ? theme.colors['action-primary-hover']
-              : theme.colors['action-input-hover'],
-          },
-          [SwitchHandleSC]: {
-            backgroundColor: $checked
-              ? theme.colors['action-always-white']
-              : theme.colors['action-link-active'],
-          },
-        },
-      }),
-}))
-
-const SwitchToggleSC = styled.div<{
-  $disabled: boolean
   $focused: boolean
-  $checked: boolean
-}>(({ $checked, $focused, $disabled, theme }) => ({
-  position: 'relative',
-  width: 42,
-  height: 24,
-  borderRadius: 12,
-  backgroundColor: $checked
-    ? $disabled
-      ? theme.colors['action-primary-disabled']
-      : theme.colors['action-primary']
-    : 'transparent',
-  outlineWidth: 1,
-  outlineStyle: 'solid',
-  outlineOffset: -1,
-  outlineColor:
-    $disabled && $checked
-      ? theme.colors['action-primary-disabled']
-      : $disabled
-      ? theme.colors['border-disabled']
-      : $focused
-      ? theme.colors['border-outline-focused']
-      : $checked
-      ? theme.colors['action-primary']
-      : theme.colors['border-input'],
-  transition: 'all 0.15s ease',
-}))
+}
 
-const SwitchHandleSC = styled.div<{ $checked: boolean; $disabled: boolean }>(
+type UseSwitchProps = Omit<
+  AriaSwitchProps & Parameters<typeof useToggleState>[0],
+  'isDisabled' | 'isReadOnly' | 'isSelected' | 'defaultSelected' | 'isRequired'
+> & {
+  checked?: boolean
+  defaultChecked?: boolean
+  disabled?: boolean
+  readOnly?: boolean
+}
+
+export type SwitchProps = UseSwitchProps &
+  Pick<typeof SwitchSC, 'as' | 'className'>
+
+const SwitchSC = styled.label<SwitchStyleProps>(
+  ({ $checked, $disabled, $readOnly, theme }) => ({
+    display: 'flex',
+    columnGap: theme.spacing.xsmall,
+    alignItems: 'center',
+    ...theme.partials.text.body2,
+    cursor: $disabled ? 'not-allowed' : $readOnly ? 'default' : 'pointer',
+    color: theme.colors['text-light'],
+    ...($disabled || $readOnly
+      ? {}
+      : {
+          '&:hover': {
+            color: theme.colors.text,
+            [SwitchToggleSC]: {
+              backgroundColor: $checked
+                ? theme.colors['action-primary-hover']
+                : theme.colors['action-input-hover'],
+              borderColor: $checked
+                ? theme.colors['action-primary-hover']
+                : theme.colors['action-input-hover'],
+            },
+            [SwitchHandleSC]: {
+              backgroundColor: $checked
+                ? theme.colors['action-always-white']
+                : theme.colors['action-link-active'],
+            },
+          },
+        }),
+  })
+)
+
+const SwitchToggleSC = styled.div<SwitchStyleProps>(
+  ({ $checked, $focused, $disabled, theme }) => ({
+    position: 'relative',
+    width: 42,
+    height: 24,
+    borderRadius: 12,
+    backgroundColor: $checked
+      ? $disabled
+        ? theme.colors['action-primary-disabled']
+        : theme.colors['action-primary']
+      : 'transparent',
+    outlineWidth: 1,
+    outlineStyle: 'solid',
+    outlineOffset: -1,
+    outlineColor:
+      $disabled && $checked
+        ? theme.colors['action-primary-disabled']
+        : $disabled
+        ? theme.colors['border-disabled']
+        : $focused
+        ? theme.colors['border-outline-focused']
+        : $checked
+        ? theme.colors['action-primary']
+        : theme.colors['border-input'],
+    transition: 'all 0.15s ease',
+  })
+)
+
+const SwitchHandleSC = styled.div<SwitchStyleProps>(
   ({ $checked, $disabled, theme }) => ({
     backgroundColor: $disabled
       ? theme.colors['border-disabled']
@@ -89,53 +105,68 @@ const SwitchHandleSC = styled.div<{ $checked: boolean; $disabled: boolean }>(
   })
 )
 
-export function Switch({
-  children,
+export const useSwitch = ({
   checked,
+  defaultChecked,
   disabled,
   readOnly,
   ...props
-}: Omit<
-  AriaSwitchProps & Parameters<typeof useToggleState>[0],
-  'isDisabled' | 'isReadonly' | 'isSelected'
-> & { checked?: boolean; disabled?: boolean; readOnly?: boolean }) {
+}: UseSwitchProps) => {
   const ariaProps: AriaSwitchProps = {
     isSelected: checked,
     isDisabled: disabled,
     isReadOnly: readOnly,
+    defaultSelected: defaultChecked,
     ...props,
   }
-  const state = useToggleState(ariaProps)
+  const state = useToggleState({
+    ...ariaProps,
+  })
   const ref = useRef<HTMLInputElement>(null)
-  const { inputProps, isSelected, isDisabled, isReadOnly } = useSwitch(
+  const { inputProps, isSelected, isDisabled, isReadOnly } = useAriaSwitch(
     { ...ariaProps },
     state,
     ref
   )
   const { focusProps, isFocusVisible } = useFocusRing()
 
+  return useMemo(
+    () => ({
+      inputProps: { ...inputProps, ...focusProps, ref },
+      styleProps: {
+        $focused: isFocusVisible,
+        $disabled: isDisabled,
+        $checked: isSelected,
+        $readOnly: isReadOnly,
+      },
+      state,
+    }),
+    [
+      focusProps,
+      inputProps,
+      isDisabled,
+      isFocusVisible,
+      isReadOnly,
+      isSelected,
+      state,
+    ]
+  )
+}
+
+export function Switch({ children, as, className, ...props }: SwitchProps) {
+  const { inputProps, styleProps } = useSwitch(props)
+
   return (
     <SwitchSC
-      $disabled={isDisabled}
-      $checked={isSelected}
-      $readOnly={isReadOnly}
+      as={as}
+      className={className}
+      {...styleProps}
     >
       <VisuallyHidden>
-        <input
-          {...inputProps}
-          {...focusProps}
-          ref={ref}
-        />
+        <input {...inputProps} />
       </VisuallyHidden>
-      <SwitchToggleSC
-        $focused={isFocusVisible}
-        $disabled={isDisabled}
-        $checked={isSelected}
-      >
-        <SwitchHandleSC
-          $disabled={isDisabled}
-          $checked={isSelected}
-        />
+      <SwitchToggleSC {...styleProps}>
+        <SwitchHandleSC {...styleProps} />
       </SwitchToggleSC>
       <div className="label">{children}</div>
     </SwitchSC>

--- a/src/components/TreeNavigation.tsx
+++ b/src/components/TreeNavigation.tsx
@@ -15,7 +15,7 @@ import {
   useState,
 } from 'react'
 import classNames from 'classnames'
-import { animated, useSpring } from 'react-spring'
+import { useSpring } from 'react-spring'
 import useMeasure from 'react-use-measure'
 import styled, { useTheme } from 'styled-components'
 import { type ImmerReducer, useImmerReducer } from 'use-immer'
@@ -27,6 +27,7 @@ import { CaretRightIcon } from '../icons'
 
 import { useNavigationContext } from './contexts/NavigationContext'
 import Tab, { TAB_INDICATOR_THICKNESS } from './Tab'
+import { AnimatedDiv } from './AnimatedDiv'
 
 export type SideNavProps = {
   desktop: boolean
@@ -396,7 +397,7 @@ export function TreeNavEntry({
         {label}
       </NavLink>
       {Children.count(children) > 0 && (
-        <animated.div
+        <AnimatedDiv
           style={{
             ...(prevHeight ? expand : { height: isOpen ? 'auto' : '0' }),
             overflow: 'hidden',
@@ -409,7 +410,7 @@ export function TreeNavEntry({
               {children}
             </SubSectionsList>
           </KeyboardNavContext.Provider>
-        </animated.div>
+        </AnimatedDiv>
       )}
     </NavEntryContext.Provider>
   )

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,6 +105,7 @@ export { Breadcrumbs } from './components/Breadcrumbs'
 export { DatePicker } from './components/DatePicker'
 export { Switch } from './components/Switch'
 export { LightDarkSwitch } from './components/LightDarkSwitch'
+export { AnimatedDiv } from './components/AnimatedDiv'
 
 // Hooks
 export { default as usePrevious } from './hooks/usePrevious'

--- a/src/stories/Table.stories.tsx
+++ b/src/stories/Table.stories.tsx
@@ -248,7 +248,6 @@ function FilterableTemplate(args: any) {
       />
       <Table
         reactTableOptions={{
-          // globalFilterFn,
           state: { globalFilter },
         }}
         {...args}

--- a/src/types/styled.d.ts
+++ b/src/types/styled.d.ts
@@ -1,6 +1,6 @@
 // import original module declarations
 import 'styled-components'
-
+import type {} from 'styled-components/cssprop'
 import { type styledTheme } from '../theme'
 
 type StyledTheme = typeof styledTheme

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ESNext",
-    "lib": ["ESNext", "DOM"],
+    "lib": ["ESNext", "ES2021", "DOM"],
     "jsx": "react-jsx",
     "allowJs": true,
     "module": "ESNext",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,18 @@
 import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
 
 // https://vitejs.dev/config/
 export default defineConfig({
   build: {
     chunkSizeWarningLimit: 1000,
   },
+  plugins: [
+    react({
+      babel: {
+        plugins: ['styled-components'],
+        babelrc: false,
+        configFile: false,
+      },
+    }),
+  ],
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2711,6 +2711,7 @@ __metadata:
     "@vitest/coverage-v8": 0.34.3
     "@vitest/ui": 0.34.3
     babel-loader: 9.1.3
+    babel-plugin-styled-components: 2.1.4
     chroma-js: 2.4.2
     classnames: 2.3.2
     conventional-changelog-conventionalcommits: 6.1.0
@@ -2759,7 +2760,7 @@ __metadata:
     styled-components: 5.3.11
     styled-container-query: 1.3.5
     type-fest: 3.13.1
-    typescript: 4.9.5
+    typescript: 5.2.2
     use-immer: 0.9.0
     usehooks-ts: 2.9.1
     vite: 4.4.9
@@ -7635,6 +7636,21 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.4.0 || ^8.0.0-0 <8.0.0
   checksum: d962200f604016a9a09bc9b4aaf60a3db7af876bb65bcefaeac04d44ac9d9ec4037cf24ce117760cc141d7046b6394c7eb0320ba9665cb4a2ee64df2be187c93
+  languageName: node
+  linkType: hard
+
+"babel-plugin-styled-components@npm:2.1.4":
+  version: 2.1.4
+  resolution: "babel-plugin-styled-components@npm:2.1.4"
+  dependencies:
+    "@babel/helper-annotate-as-pure": ^7.22.5
+    "@babel/helper-module-imports": ^7.22.5
+    "@babel/plugin-syntax-jsx": ^7.22.5
+    lodash: ^4.17.21
+    picomatch: ^2.3.1
+  peerDependencies:
+    styled-components: ">= 2"
+  checksum: d791aed68d975dae4f73055f86cd47afa99cb402b8113acdaf5678c8b6fba2cbc15543f2debe8ed09becb198aae8be2adfe268ad41f4bca917288e073a622bf8
   languageName: node
   linkType: hard
 
@@ -18469,6 +18485,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typescript@npm:5.2.2":
+  version: 5.2.2
+  resolution: "typescript@npm:5.2.2"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 7912821dac4d962d315c36800fe387cdc0a6298dba7ec171b350b4a6e988b51d7b8f051317786db1094bd7431d526b648aba7da8236607febb26cf5b871d2d3c
+  languageName: node
+  linkType: hard
+
 "typescript@patch:typescript@4.9.5#~builtin<compat/typescript>":
   version: 4.9.5
   resolution: "typescript@patch:typescript@npm%3A4.9.5#~builtin<compat/typescript>::version=4.9.5&hash=ad5954"
@@ -18476,6 +18502,16 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 8f6260acc86b56bfdda6004bc53f32ea548f543e8baef7071c8e34d29d292f3e375c8416556c8de10b24deef6933cd1c16a8233dc84a3dd43a13a13265d0faab
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@5.2.2#~builtin<compat/typescript>":
+  version: 5.2.2
+  resolution: "typescript@patch:typescript@npm%3A5.2.2#~builtin<compat/typescript>::version=5.2.2&hash=ad5954"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 07106822b4305de3f22835cbba949a2b35451cad50888759b6818421290ff95d522b38ef7919e70fb381c5fe9c1c643d7dea22c8b31652a717ddbd57b7f4d554
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Switch component hover style fixed
- Switch component can now be styled via styled-components
- Enabled use of styled-components `css` prop, which should help with the incremental migration away from honorable.