### PR TITLE
feat: Modal and Input improvements

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -23,6 +23,7 @@ function ButtonRef(
       animationName={pulse ? pulseKeyframes : undefined}
       boxShadow={pulse ? '0 0 7px 2px #fff1' : undefined}
       _hover={{ animationPlayState: 'paused' }}
+      type="button"
       {...props}
     />
   )

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -1,4 +1,4 @@
-import { ExtendTheme, Input as HonorableInput, mergeTheme } from 'honorable'
+import { ExtendTheme, Input as HonorableInput } from 'honorable'
 import type { InputProps as HonorableInputProps } from 'honorable'
 import { type ComponentProps, type ReactNode, forwardRef, useRef } from 'react'
 import styled from 'styled-components'
@@ -95,7 +95,46 @@ const Input = forwardRef(
       ...(inputProps ?? {}),
       ref: mergeRefs([inputRef, ...(inputProps?.ref ? [inputProps.ref] : [])]),
     }
-    let themeExtension: any = {}
+    const themeExtension: any = {
+      Input: {
+        Root: [
+          {
+            paddingLeft: 0,
+            paddingRight: 0,
+          },
+        ],
+        InputBase: [
+          {
+            paddingLeft: prefix
+              ? 'xsmall'
+              : titleContent
+              ? startIcon
+                ? 'xsmall'
+                : 'small'
+              : 'medium',
+            paddingRight: suffix
+              ? 'xsmall'
+              : showClearButton || endIcon
+              ? 'xsmall'
+              : 'medium',
+          },
+        ],
+        StartIcon: [
+          {
+            ...startEndStyles,
+            paddingLeft: prefix || titleContent ? 0 : 'medium',
+            marginRight: 0,
+          },
+        ],
+        EndIcon: [
+          {
+            ...startEndStyles,
+            paddingRight: suffix || showClearButton ? 0 : 'medium',
+            marginLeft: 0,
+          },
+        ],
+      },
+    }
     const parentFillLevel = useFillLevel()
     const size = (props as any).large
       ? 'large'
@@ -103,60 +142,39 @@ const Input = forwardRef(
       ? 'small'
       : 'medium'
 
-    if (suffix || showClearButton) {
-      themeExtension = mergeTheme(themeExtension, {
-        Input: {
-          Root: [{ paddingRight: 0 }],
-          EndIcon: [
-            { ...startEndStyles, ...{ paddingLeft: 'xsmall', gap: 0 } },
-          ],
-        },
-      })
-    }
-    if (prefix || titleContent) {
-      themeExtension = mergeTheme(themeExtension, {
-        Input: {
-          Root: [{ paddingLeft: 0 }],
-          StartIcon: [
-            {
-              ...startEndStyles,
-              ...{
-                paddingRight: titleContent && !startIcon ? 'small' : 'xsmall',
-              },
-            },
-          ],
-        },
-      })
-    }
     inputProps = mergeProps(useFormField()?.fieldProps ?? {}, inputProps)
+    const hasEndIcon = (showClearButton && props.value) || endIcon || suffix
+    const hasStartIcon = startIcon || prefix || titleContent
 
     return (
       <ExtendTheme theme={themeExtension}>
         <HonorableInput
           ref={ref}
           endIcon={
-            <>
-              {showClearButton && props.value && (
-                <ClearButton
-                  onClick={() => {
-                    const input = inputRef?.current
+            hasEndIcon && (
+              <>
+                {showClearButton && props.value && (
+                  <ClearButton
+                    onClick={() => {
+                      const input = inputRef?.current
 
-                    if (input) {
-                      simulateInputChange(input, '')
-                    }
-                  }}
-                />
-              )}
-              {endIcon || suffix ? (
-                <>
-                  {endIcon}
-                  {suffix && <PrefixSuffix>{suffix}</PrefixSuffix>}
-                </>
-              ) : undefined}
-            </>
+                      if (input) {
+                        simulateInputChange(input, '')
+                      }
+                    }}
+                  />
+                )}
+                {endIcon || suffix ? (
+                  <>
+                    {endIcon}
+                    {suffix && <PrefixSuffix>{suffix}</PrefixSuffix>}
+                  </>
+                ) : undefined}
+              </>
+            )
           }
           startIcon={
-            startIcon || prefix || titleContent ? (
+            hasStartIcon ? (
               <>
                 {(titleContent && (
                   <InputTitleContent

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,12 +1,8 @@
 import { type ReactNode, type Ref, forwardRef, useEffect } from 'react'
-import {
-  Div,
-  Flex,
-  H1,
-  Modal as HonorableModal,
-  type ModalProps,
-} from 'honorable'
+import { Flex, H1, Modal as HonorableModal, type ModalProps } from 'honorable'
 import PropTypes from 'prop-types'
+
+import styled, { type StyledComponentPropsWithRef } from 'styled-components'
 
 import { type ColorKey, type SeverityExt } from '../types'
 
@@ -37,6 +33,8 @@ type ModalPropsType = Omit<ModalProps, 'size'> & {
   actions?: ReactNode
   severity?: ModalSeverity
   lockBody?: boolean
+  asForm?: boolean
+  formProps?: StyledComponentPropsWithRef<'form'>
   [x: string]: unknown
 }
 
@@ -73,17 +71,38 @@ const sizeToWidth = {
   large: 608,
 } as const satisfies Record<ModalSize, number>
 
+const ModalSC = styled.div((_) => ({
+  position: 'relative',
+}))
+
+const ModalContentSC = styled.div<{ $hasActions: boolean }>(
+  ({ theme, $hasActions }) => ({
+    margin: theme.spacing.large,
+    marginBottom: $hasActions ? 0 : theme.spacing.large,
+    ...theme.partials.text.body1,
+  })
+)
+
+const ModalActionsSC = styled.div((_) => ({
+  display: 'flex',
+  position: 'sticky',
+  flexDirection: 'column',
+  bottom: '0',
+}))
+
 function ModalRef(
   {
     children,
     header,
     actions,
-    form = false,
     open = false,
+    form = false,
     size = form ? 'large' : 'medium',
     onClose,
     severity,
     lockBody = true,
+    asForm = false,
+    formProps = {},
     ...props
   }: ModalPropsType,
   ref: Ref<any>
@@ -97,6 +116,8 @@ function ModalRef(
     setBodyLocked(lockBody && open)
   }, [lockBody, open, setBodyLocked])
 
+  console.log('formprops', formProps)
+
   return (
     <HonorableModal
       open={open}
@@ -108,55 +129,52 @@ function ModalRef(
       maxWidth={sizeToWidth[size]}
       {...props}
     >
-      <Div
-        margin="large"
-        marginBottom={actions ? 0 : 'large'}
-        body1
+      <ModalSC
+        as={asForm ? 'form' : undefined}
+        {...(asForm ? formProps : {})}
       >
-        {!!header && (
-          <Flex
-            ref={ref}
-            align="center"
-            justify="start"
-            marginBottom="large"
-            gap="xsmall"
-          >
-            {HeaderIcon && (
-              <HeaderIcon
-                marginTop={-2} // optically center icon
-                color={iconColorKey}
-              />
-            )}
-            <H1
-              overline
-              color="text-xlight"
+        <ModalContentSC $hasActions={!!actions}>
+          {!!header && (
+            <Flex
+              ref={ref}
+              align="center"
+              justify="start"
+              marginBottom="large"
+              gap="xsmall"
             >
-              {header}
-            </H1>
-          </Flex>
+              {HeaderIcon && (
+                <HeaderIcon
+                  marginTop={-2} // optically center icon
+                  color={iconColorKey}
+                />
+              )}
+              <H1
+                overline
+                color="text-xlight"
+              >
+                {header}
+              </H1>
+            </Flex>
+          )}
+          {children}
+        </ModalContentSC>
+        {!!actions && (
+          <ModalActionsSC>
+            <Flex
+              background="linear-gradient(180deg, transparent 0%, fill-one 100%);"
+              height={16}
+            />
+            <Flex
+              padding="large"
+              align="center"
+              justify="flex-end"
+              backgroundColor="fill-one"
+            >
+              {actions}
+            </Flex>
+          </ModalActionsSC>
         )}
-        {children}
-      </Div>
-      {!!actions && (
-        <Flex
-          position="sticky"
-          direction="column"
-          bottom="0"
-        >
-          <Flex
-            background="linear-gradient(180deg, transparent 0%, fill-one 100%);"
-            height={16}
-          />
-          <Flex
-            padding="large"
-            align="center"
-            justify="flex-end"
-            backgroundColor="fill-one"
-          >
-            {actions}
-          </Flex>
-        </Flex>
-      )}
+      </ModalSC>
     </HonorableModal>
   )
 }

--- a/src/stories/Input.stories.tsx
+++ b/src/stories/Input.stories.tsx
@@ -13,6 +13,28 @@ export default {
   component: Input,
 }
 
+function InputSet(props: any) {
+  return (
+    <Flex
+      direction="column"
+      gap="small"
+    >
+      <Input {...props} />
+      <Input
+        startIcon={<MagnifyingGlassIcon />}
+        endIcon={
+          <CaretDownIcon
+            size={10}
+            mt={0.333}
+            mx="3px"
+          />
+        }
+        {...props}
+      />
+    </Flex>
+  )
+}
+
 function Template(args: any) {
   const [inputVal, setInputVal] = useState('')
 
@@ -28,21 +50,17 @@ function Template(args: any) {
     <Flex
       direction="column"
       maxWidth="400px"
+      gap="large"
     >
-      <Input {...props} />
-      <Div marginTop="medium">
-        <Input
-          startIcon={<MagnifyingGlassIcon />}
-          endIcon={
-            <CaretDownIcon
-              size={10}
-              mt={0.333}
-              mx="3px"
-            />
-          }
-          {...props}
-        />
-      </Div>
+      <InputSet
+        {...props}
+        large
+      />
+      <InputSet {...props} />
+      <InputSet
+        {...props}
+        small
+      />
     </Flex>
   )
 }

--- a/src/stories/Modal.stories.tsx
+++ b/src/stories/Modal.stories.tsx
@@ -1,7 +1,7 @@
-import { Button, Div, H3, P } from 'honorable'
+import { Div, H3, P } from 'honorable'
 import { useState } from 'react'
 
-import { Card, FormField, Input, Modal } from '..'
+import { Button, Card, FormField, Input, Modal } from '..'
 import { SEVERITIES } from '../components/Modal'
 
 export default {
@@ -43,6 +43,7 @@ function Template(args: any) {
                 Cancel
               </Button>
               <Button
+                type="submit"
                 primary
                 destructive={!args.form}
                 marginLeft="medium"
@@ -52,6 +53,13 @@ function Template(args: any) {
             </>
           )
         }
+        asForm={!!args.form}
+        formProps={{
+          onSubmit: (e) => {
+            e.preventDefault()
+            alert('Form submitted')
+          },
+        }}
         {...args}
       >
         {!args.form && (

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -580,6 +580,25 @@ const getHonorableThemeProps = ({ mode }: { mode: ColorMode }) => {
             },
           },
       ],
+      TextArea: [
+        {
+          paddingLeft: 'medium',
+          paddingRight: 'medium',
+          lineHeight: 'inherit',
+          paddingTop: 9,
+          paddingBottom: 9,
+        },
+        ({ small }: any) =>
+          small && {
+            paddingTop: 7,
+            paddingBottom: 7,
+          },
+        ({ large }: any) =>
+          large && {
+            paddingTop: 13,
+            paddingBottom: 13,
+          },
+      ],
       StartIcon: [
         {
           marginRight: 'xsmall',
@@ -644,10 +663,10 @@ const getHonorableThemeProps = ({ mode }: { mode: ColorMode }) => {
           backgroundColor: 'fill-one',
           border: '1px solid border',
           boxShadow: 'modal',
-          paddingTop: 'large',
-          paddingRight: 'large',
-          paddingBottom: 'large',
-          paddingLeft: 'large',
+          paddingTop: 0,
+          paddingRight: 0,
+          paddingBottom: 0,
+          paddingLeft: 0,
         },
       ],
       Backdrop: [


### PR DESCRIPTION
- Remove excessive padding on Modals (this also fixes issue with scrolling content appearing below action buttons) 
- Allow Modals to be rendered as forms using `asForm` and `formProps` so actions can trigger form submission 
- Default Buttons to `type="button"` to prevent accidentally submitting forms on click.
- Fix wonky margins/padding on Inputs