### PR TITLE
fix: Modal closing when pressing any character in the string “Escape”

### DIFF
--- a/src/components/HonorableModal.tsx
+++ b/src/components/HonorableModal.tsx
@@ -100,7 +100,7 @@ function ModalRef(props: ModalProps, ref: Ref<any>) {
     [isOpen, isClosing, disableEscapeKey, handleClose]
   )
 
-  useKeyDown('Escape', handleEscapeKey)
+  useKeyDown(['Escape'], handleEscapeKey)
 
   useEffect(() => {
     if (fade && open) {


### PR DESCRIPTION
Now properly closes when pressing Escape key.