### PR TITLE
fix: Pricing Calculator crash + Typescript fixes

### DIFF
--- a/src/components/Chip.tsx
+++ b/src/components/Chip.tsx
@@ -8,6 +8,8 @@ import {
 } from 'react'
 import styled, { type DefaultTheme, useTheme } from 'styled-components'
 
+import { SEVERITIES } from '../types'
+
 import { Spinner } from './Spinner'
 import Card, { type BaseCardProps } from './Card'
 import { type FillLevel, useFillLevel } from './contexts/FillLevelContext'
@@ -15,14 +17,6 @@ import CloseIcon from './icons/CloseIcon'
 
 const HUES = ['default', 'lighter', 'lightest'] as const
 const SIZES = ['small', 'medium', 'large'] as const
-const SEVERITIES = [
-  'neutral',
-  'info',
-  'success',
-  'warning',
-  'error',
-  'critical',
-] as const
 
 type ChipHue = (typeof HUES)[number]
 type ChipSize = (typeof SIZES)[number]
@@ -65,8 +59,10 @@ const severityToColor = {
   info: 'text-primary-accent',
   success: 'text-success-light',
   warning: 'text-warning-light',
-  error: 'text-danger-light',
+  danger: 'text-danger-light',
   critical: 'text-danger',
+  // deprecated
+  error: 'text-danger-light',
 } as const satisfies Record<ChipSeverity, string>
 
 const severityToIconColor = {
@@ -74,8 +70,10 @@ const severityToIconColor = {
   info: 'icon-info',
   success: 'icon-success',
   warning: 'icon-warning',
-  error: 'icon-danger',
+  danger: 'icon-danger',
   critical: 'icon-danger-critical',
+  // deprecated
+  error: 'icon-danger',
 } as const satisfies Record<ChipSeverity, keyof DefaultTheme['colors']>
 
 const sizeToCloseHeight = {

--- a/src/components/ListBox.tsx
+++ b/src/components/ListBox.tsx
@@ -89,6 +89,20 @@ const ScrollContainer = styled.div<ScrollContainerProps>(
   })
 )
 
+function propsToTextValue({
+  textValue,
+  children,
+  label,
+}: Record<string, unknown>) {
+  return typeof textValue === 'string' && textValue
+    ? textValue
+    : typeof label === 'string' && label
+    ? label
+    : typeof children === 'string' && children
+    ? children
+    : ''
+}
+
 function useItemWrappedChildren(
   children: ReactElement | ReactElement[],
   header?: ReactElement,
@@ -100,16 +114,25 @@ function useItemWrappedChildren(
     const wrapped: JSX.Element[] = []
 
     if (header) {
-      wrapped.push(<Item key={HEADER_KEY}>{header}</Item>)
+      const { textValue: _, ...headerProps } = header.props
+
+      wrapped.push(
+        <Item
+          textValue={propsToTextValue(header.props)}
+          key={HEADER_KEY}
+        >
+          {cloneElement(header, headerProps)}
+        </Item>
+      )
     }
     Children.forEach(children, (child) => {
-      const { textValue, ...childProps } = child?.props || {}
+      const { textValue: _, ...childProps } = child.props
 
       if (child) {
         const item = (
           <Item
             key={child.key}
-            textValue={textValue || ''}
+            textValue={propsToTextValue(child.props)}
           >
             {cloneElement(child, childProps)}
           </Item>
@@ -120,7 +143,16 @@ function useItemWrappedChildren(
     })
 
     if (footer) {
-      wrapped.push(<Item key={FOOTER_KEY}>{footer}</Item>)
+      const { textValue: _, ...footerProps } = footer.props
+
+      wrapped.push(
+        <Item
+          textValue={propsToTextValue(footer.props)}
+          key={FOOTER_KEY}
+        >
+          {cloneElement(footer, footerProps)}
+        </Item>
+      )
     }
 
     return wrapped

--- a/src/components/SelectItem.tsx
+++ b/src/components/SelectItem.tsx
@@ -5,10 +5,7 @@ import {
   cloneElement,
   forwardRef,
   useContext,
-  useEffect,
-  useId,
   useRef,
-  useState,
 } from 'react'
 import styled from 'styled-components'
 
@@ -48,50 +45,19 @@ const SelectItemWrap = styled.label<SelectItemWrapProps>(
 type SelectItemProps = AriaRadioProps & {
   icon: ReactElement
   label?: string
-  selected?: boolean
-  defaultSelected?: boolean
-  checked?: boolean
   name?: string
-  onChange?: (e: { target: { checked: boolean } }) => void
+  className?: string
 }
 
-const SelectItem = forwardRef<HTMLDivElement, SelectItemProps>(
-  ({
-    icon,
-    label,
-    value,
-    checked: checkedProp,
-    defaultSelected,
-    'aria-describedby': ariaDescribedBy,
-    onChange,
-    onBlur,
-    onFocus,
-    onKeyDown,
-    onKeyUp,
-    name,
-  }) => {
-    const [checked, setChecked] = useState(defaultSelected || checkedProp)
-    const state = useContext(RadioContext) || {
-      setSelectedValue: () => {},
-      selectedValue: checkedProp || checked ? value : undefined,
-    }
-
-    useEffect(() => {
-      setChecked(checkedProp)
-    }, [checkedProp])
-
-    const labelId = useId()
+const SelectItem = forwardRef<any, SelectItemProps>(
+  ({ icon, label, value, name, className, ...props }, ref) => {
+    const state = useContext(RadioContext)
     const inputRef = useRef<any>()
     const { isFocusVisible, focusProps } = useFocusRing()
     const { inputProps, isSelected } = useRadio(
       {
         value,
-        'aria-describedby': ariaDescribedBy,
-        'aria-labelledby': labelId,
-        onBlur,
-        onFocus,
-        onKeyDown,
-        onKeyUp,
+        ...props,
       },
       state,
       inputRef
@@ -103,6 +69,8 @@ const SelectItem = forwardRef<HTMLDivElement, SelectItemProps>(
       <SelectItemWrap
         selected={isSelected}
         focused={isFocusVisible}
+        className={className}
+        ref={ref}
       >
         {icon}
         {label && <div className="label">{label}</div>}
@@ -111,13 +79,6 @@ const SelectItem = forwardRef<HTMLDivElement, SelectItemProps>(
             {...inputProps}
             {...focusProps}
             name={inputProps.name || name}
-            onChange={(e) => {
-              if (typeof onChange === 'function') {
-                onChange(e)
-              }
-              setChecked(!checked)
-              inputProps.onChange(e)
-            }}
             ref={inputRef}
           />
         </VisuallyHidden>

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -65,9 +65,8 @@ export type TableProps = Omit<
   scrollTopMargin?: number
   virtualizeRows?: boolean
   lockColumnsOnFirstScroll?: boolean
-  reactVirtualOptions?: Omit<
-    Parameters<typeof useVirtualizer>[0],
-    'count' | 'getScrollElement'
+  reactVirtualOptions?: Partial<
+    Omit<Parameters<typeof useVirtualizer>[0], 'count' | 'getScrollElement'>
   >
   reactTableOptions?: Partial<Omit<TableOptions<any>, 'data' | 'columns'>>
   onRowClick?: (e: MouseEvent<HTMLTableRowElement>, row: Row<any>) => void

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -34,6 +34,8 @@ import { useVirtualizer } from '@tanstack/react-virtual'
 import styled, { useTheme } from 'styled-components'
 import { isEmpty, isNil } from 'lodash-es'
 
+import usePrevious from '../hooks/usePrevious'
+
 import Button from './Button'
 import CaretUpIcon from './icons/CaretUpIcon'
 import ArrowRightIcon from './icons/ArrowRightIcon'
@@ -52,9 +54,15 @@ export type TableProps = Omit<
   | 'scrollTopMargin'
   | 'virtualizeRows'
   | 'virtualizerOptions'
+  | 'lockColumnsOnFirstScroll'
+  | 'reactVirtualOptions'
   | 'reactTableOptions'
   | 'onRowClick'
   | 'emptyStateProps'
+  | 'hasNextPage'
+  | 'fetchNextPage'
+  | 'isFetchingNextPage'
+  | 'onVirtualWindowChange'
 > & {
   data: any[]
   columns: any[]
@@ -74,6 +82,10 @@ export type TableProps = Omit<
   hasNextPage?: boolean
   fetchNextPage?: () => void
   isFetchingNextPage?: boolean
+  onVirtualSliceChange?: (slice: {
+    start: VirtualItem
+    end: VirtualItem
+  }) => void
 }
 
 const propTypes = {}
@@ -457,6 +469,40 @@ function useOnFirstScroll(
   }, [hasScrolled, onFirstScroll, ref])
 }
 
+function useOnVirtualSliceChange({
+  virtualRows,
+  virtualizeRows,
+  onVirtualSliceChange,
+}: {
+  virtualRows: VirtualItem[]
+  virtualizeRows: boolean
+  onVirtualSliceChange: (slice: {
+    start: VirtualItem
+    end: VirtualItem
+  }) => void
+}) {
+  const sliceStartRow = virtualRows[0]
+  const sliceEndRow = virtualRows[virtualRows.length - 1]
+  const prevSliceStartRow = usePrevious(virtualRows[0])
+  const prevSliceEndRow = usePrevious(virtualRows[virtualRows.length - 1])
+
+  useEffect(() => {
+    if (
+      virtualizeRows &&
+      (prevSliceEndRow !== sliceEndRow || prevSliceStartRow !== sliceStartRow)
+    ) {
+      onVirtualSliceChange?.({ start: sliceStartRow, end: sliceEndRow })
+    }
+  }, [
+    sliceStartRow,
+    sliceEndRow,
+    virtualizeRows,
+    onVirtualSliceChange,
+    prevSliceEndRow,
+    prevSliceStartRow,
+  ])
+}
+
 function TableRef(
   {
     data,
@@ -476,6 +522,7 @@ function TableRef(
     hasNextPage,
     isFetchingNextPage,
     fetchNextPage,
+    onVirtualSliceChange,
     ...props
   }: TableProps,
   forwardRef: Ref<any>
@@ -514,9 +561,13 @@ function TableRef(
   >(null)
 
   const { rows: tableRows } = table.getRowModel()
+  const getItemKey = useCallback<
+    Parameters<typeof useVirtualizer>[0]['getItemKey']
+  >((i) => tableRows[i]?.id || i, [tableRows])
   const rowVirtualizer = useVirtualizer({
     count: hasNextPage ? tableRows.length + 1 : tableRows.length,
     overscan: 6,
+    getItemKey,
     getScrollElement: () => tableContainerRef.current,
     estimateSize: () => 52,
     measureElement: (el) => {
@@ -537,6 +588,8 @@ function TableRef(
   })
   const virtualRows = rowVirtualizer.getVirtualItems()
   const virtualHeight = rowVirtualizer.getTotalSize()
+
+  useOnVirtualSliceChange({ virtualRows, virtualizeRows, onVirtualSliceChange })
 
   lockColumnsOnFirstScroll = lockColumnsOnFirstScroll ?? virtualizeRows
   useOnFirstScroll(

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,10 +1,16 @@
 import { type FlexProps } from 'honorable'
 import { type Ref, forwardRef, useCallback, useEffect, useState } from 'react'
 
+import { type Severity } from '../types'
+import { type Extends } from '../utils/ts-utils'
+
 import Banner from './Banner'
 import Layer, { type LayerPositionType } from './Layer'
 
-export type Severity = 'info' | 'success' | 'error'
+export type ToastSeverity = Extends<
+  Severity,
+  'info' | 'success' | 'danger' | 'error'
+>
 
 type ToastProps = {
   position?: LayerPositionType
@@ -12,7 +18,7 @@ type ToastProps = {
   onClose?: () => void
   onCloseComplete?: () => void
   show?: boolean
-  severity?: Severity
+  severity?: ToastSeverity
 } & FlexProps
 
 const defaults = {
@@ -20,7 +26,7 @@ const defaults = {
   position: 'bottom-right' as LayerPositionType,
   onClose: () => {},
   onCloseComplete: () => {},
-  severity: 'info' as Severity,
+  severity: 'info' as ToastSeverity,
 }
 
 const Toast = forwardRef(
@@ -99,7 +105,7 @@ function GraphQLToast({
 }: GraphQLToastProps): JSX.Element {
   return (
     <Toast
-      severity="error"
+      severity="danger"
       {...props}
     >
       {header}: {error?.graphQLErrors[0]?.message}

--- a/src/components/pricingcalculator/controls/Control.tsx
+++ b/src/components/pricingcalculator/controls/Control.tsx
@@ -1,4 +1,5 @@
-import { type ReactElement } from 'react'
+import { type FocusableElement } from '@react-types/shared'
+import { type DOMAttributes, type ReactElement } from 'react'
 import styled from 'styled-components'
 
 const ControlWrap = styled.div(({ theme }) => ({
@@ -24,15 +25,25 @@ type ControlProps = {
   header: string
   caption?: string
   children: ReactElement | ReactElement[] | string
+  labelProps?: DOMAttributes<FocusableElement>
 }
 
-export default function Control({ header, caption, children }: ControlProps) {
+export default function Control({
+  header,
+  caption,
+  children,
+  labelProps,
+}: ControlProps) {
   return (
     <ControlWrap>
-      <div className={`header ${caption ? 'with-caption' : 'without-caption'}`}>
-        {header}
+      <div {...labelProps}>
+        <div
+          className={`header ${caption ? 'with-caption' : 'without-caption'}`}
+        >
+          {header}
+        </div>
+        {caption && <div className="caption">{caption}</div>}
       </div>
-      <div className="caption">{caption}</div>
       {children}
     </ControlWrap>
   )

--- a/src/components/pricingcalculator/controls/ProvidersControl.tsx
+++ b/src/components/pricingcalculator/controls/ProvidersControl.tsx
@@ -1,8 +1,11 @@
 import { type Dispatch, createElement } from 'react'
 import styled from 'styled-components'
+import { useRadioGroupState } from 'react-stately'
+import { useRadioGroup } from 'react-aria'
 
 import SelectItem from '../../SelectItem'
 import { PROVIDERS } from '../misc'
+import { RadioContext } from '../../RadioGroup'
 
 import Control from './Control'
 
@@ -25,23 +28,37 @@ export default function ProviderControl({
   providerId,
   setProviderId,
 }: ProviderControlProps) {
+  const providerRadioGroupProps = {
+    label: header,
+    description: 'caption',
+    value: providerId,
+    onChange: (id: string) => {
+      setProviderId(id)
+    },
+  }
+  const state = useRadioGroupState(providerRadioGroupProps)
+  const { radioGroupProps, labelProps } = useRadioGroup(
+    providerRadioGroupProps,
+    state
+  )
+
   return (
     <Control
       header={header}
       caption={caption}
+      labelProps={labelProps}
     >
-      <ProvidersWrap>
-        {PROVIDERS.map(({ id, name, icon }) => (
-          <SelectItem
-            label={name}
-            icon={createElement(icon, { fullColor: true })}
-            value={id}
-            checked={providerId === id}
-            onChange={({ target: { checked } }: any) => {
-              if (checked) setProviderId(id)
-            }}
-          />
-        ))}
+      <ProvidersWrap {...radioGroupProps}>
+        <RadioContext.Provider value={state}>
+          {PROVIDERS.map(({ id, name, icon }) => (
+            <SelectItem
+              label={name}
+              name={name}
+              icon={createElement(icon, { fullColor: true })}
+              value={id}
+            />
+          ))}
+        </RadioContext.Provider>
       </ProvidersWrap>
     </Control>
   )

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,7 +105,6 @@ export type {
   AppMenuAction,
 } from './components/AppList'
 export { AppList } from './components/AppList'
-export { default as SelectItem } from './components/SelectItem'
 export { default as Slider } from './components/Slider'
 export { default as PricingCalculator } from './components/pricingcalculator/PricingCalculator'
 export { default as PricingCalculatorExtended } from './components/pricingcalculator/PricingCalculatorExtended'

--- a/src/stories/Chip.stories.tsx
+++ b/src/stories/Chip.stories.tsx
@@ -137,7 +137,7 @@ function Template({ onFillLevel, asLink, ...args }: any) {
               Local
             </Chip>
             <Chip
-              severity="error"
+              severity="danger"
               size="small"
               {...args}
             >

--- a/src/stories/ComboBox.stories.tsx
+++ b/src/stories/ComboBox.stories.tsx
@@ -71,7 +71,7 @@ const chips = [
     Additional
   </Chip>,
   <Chip
-    severity="error"
+    severity="danger"
     {...chipProps}
   >
     Extra

--- a/src/stories/ListBox.stories.tsx
+++ b/src/stories/ListBox.stories.tsx
@@ -56,7 +56,7 @@ const chips = [
     Additional
   </Chip>,
   <Chip
-    severity="error"
+    severity="danger"
     {...chipProps}
   >
     Extra

--- a/src/stories/Select.stories.tsx
+++ b/src/stories/Select.stories.tsx
@@ -86,7 +86,7 @@ const chips = [
     Additional
   </Chip>,
   <Chip
-    severity="error"
+    severity="danger"
     {...chipProps}
   >
     Extra

--- a/src/stories/Toast.stories.tsx
+++ b/src/stories/Toast.stories.tsx
@@ -2,7 +2,7 @@ import { Button, Flex } from 'honorable'
 import { useState } from 'react'
 
 import { type LayerPositionType } from '../components/Layer'
-import { GraphQLToast, type Severity, Toast } from '../components/Toast'
+import { GraphQLToast, type ToastSeverity, Toast } from '../components/Toast'
 
 export default {
   title: 'Toast',
@@ -21,7 +21,7 @@ export default {
 }
 
 type Args = {
-  severity: Severity
+  severity: ToastSeverity
   closeTimeout?: number
 }
 

--- a/src/stories/Toast.stories.tsx
+++ b/src/stories/Toast.stories.tsx
@@ -2,7 +2,7 @@ import { Button, Flex } from 'honorable'
 import { useState } from 'react'
 
 import { type LayerPositionType } from '../components/Layer'
-import { GraphQLToast, type ToastSeverity, Toast } from '../components/Toast'
+import { GraphQLToast, Toast, type ToastSeverity } from '../components/Toast'
 
 export default {
   title: 'Toast',

--- a/src/utils/ts-utils.ts
+++ b/src/utils/ts-utils.ts
@@ -79,3 +79,5 @@ export function affixKeysToValues<
     ])
   ) as AffixKeyToValue<T, Prefix, Suffix>
 }
+
+export type Extends<T, U extends T> = U


### PR DESCRIPTION
- Fix crash with Pricing Calculator
- Add `danger` severity option for `Chips` and `Toasts` to bring severities into alignment across design system
- Automatically set `textValue` for `ListBoxItem`s when possible to reduce `react-aria` warnings
- Fix issue where `Table` was requiring unneeded props for `reactVirtualOptions`
- `Table` - Add ability to listen to changes in virtual rows with `onVirtualSliceChange`