### PR TITLE
fix: Incorrect styling of `IconFrame` when using `as` prop

### DIFF
--- a/src/components/IconFrame.tsx
+++ b/src/components/IconFrame.tsx
@@ -1,4 +1,5 @@
 import {
+  type ComponentProps,
   type ReactElement,
   type ReactNode,
   cloneElement,
@@ -143,7 +144,10 @@ const IconFrameSC = styled(Flex)<{
     : {}),
 }))
 
-const IconFrame = forwardRef<HTMLDivElement, IconFrameProps>(
+const IconFrame = forwardRef<
+  HTMLDivElement,
+  IconFrameProps & ComponentProps<typeof IconFrameSC>
+>(
   (
     {
       icon,
@@ -154,6 +158,7 @@ const IconFrame = forwardRef<HTMLDivElement, IconFrameProps>(
       tooltip,
       tooltipProps,
       type = 'tertiary',
+      as,
       ...props
     },
     ref
@@ -162,6 +167,7 @@ const IconFrame = forwardRef<HTMLDivElement, IconFrameProps>(
     if (tooltip && typeof tooltip === 'boolean') {
       tooltip = textValue
     }
+    const forwardedAs = as || (clickable ? ButtonBase : undefined)
 
     let content = (
       <IconFrameSC
@@ -172,9 +178,8 @@ const IconFrame = forwardRef<HTMLDivElement, IconFrameProps>(
         ref={ref}
         flex={false}
         aria-label={textValue}
-        forwardedAs={(props as any).as}
+        {...(forwardedAs ? { forwardedAs } : {})}
         {...(clickable && {
-          forwardedAs: (props as any).as || ButtonBase,
           tabIndex: 0,
           role: 'button',
           type: 'button',


### PR DESCRIPTION
Fixes issue where `IconFrame`s using the `as` prop would have incorrect styling.

Before:
<img width="56" alt="Screenshot 2023-12-18 at 12 42 16 PM" src="https://github.com/pluralsh/design-system/assets/85062/dd20b55f-1458-43e8-bbf2-6796103ca274">

After:
<img width="63" alt="Screenshot 2023-12-18 at 12 41 09 PM" src="https://github.com/pluralsh/design-system/assets/85062/d86cdfd7-41e1-4874-98bf-90c252fc2533">
