### PR TITLE
feat: Add `TextSwitch` component

### DIFF
--- a/src/components/ComboBox.tsx
+++ b/src/components/ComboBox.tsx
@@ -249,6 +249,7 @@ function ComboBox({
   titleContent,
   showClearButton,
   chips,
+  inputContent,
   onDeleteChip: onDeleteChipProp,
   ...props
 }: ComboBoxProps) {
@@ -358,6 +359,7 @@ function ComboBox({
 
   const buttonRef = useRef(null)
   const inputRef = useRef(null)
+  const inputInnerRef = useRef(null)
   const listBoxRef = useRef(null)
   const popoverRef = useRef(null)
 
@@ -420,7 +422,7 @@ function ComboBox({
 
     if (dir === 0) return
 
-    if (elt instanceof HTMLInputElement) {
+    if (elt === inputInnerRef.current && elt instanceof HTMLInputElement) {
       if (elt.selectionStart !== 0 || dir !== -1) {
         return
       }
@@ -440,7 +442,7 @@ function ComboBox({
 
       if (dir === 1) {
         if (!chip.nextElementSibling) {
-          inputRef.current?.querySelector('input')?.focus()
+          inputInnerRef.current?.focus()
         } else {
           chip?.nextElementSibling
             ?.querySelector(`[${CHIP_CLOSE_ATTR_KEY}]`)
@@ -458,36 +460,37 @@ function ComboBox({
 
   outerInputProps = useMemo(
     () => ({
-      ...(!isEmpty(chips)
-        ? {
-            inputContent: (
-              <InputChipList
-                ref={chipListRef}
-                onKeyDown={handleKeyDown}
-              >
-                {chips.map((chipProps) => (
-                  <Chip
-                    size="small"
-                    condensed
-                    truncateWidth={100}
-                    truncateEdge="start"
-                    closeButton
-                    tooltip
-                    onClick={onChipClick}
-                    closeButtonProps={{
-                      onClick: () => {
-                        onDeleteChip?.(chipProps?.key)
-                      },
-                      'aria-label': `Remove ${chipProps.key}`,
-                    }}
-                    {...{ [CHIP_ATTR_KEY]: chipProps?.key }}
-                    {...chipProps}
-                  />
-                ))}
-              </InputChipList>
-            ),
-          }
-        : {}),
+      inputContent: (
+        <>
+          {inputContent}
+          {!isEmpty(chips) && (
+            <InputChipList
+              ref={chipListRef}
+              onKeyDown={handleKeyDown}
+            >
+              {chips.map((chipProps) => (
+                <Chip
+                  size="small"
+                  condensed
+                  truncateWidth={100}
+                  truncateEdge="start"
+                  closeButton
+                  tooltip
+                  onClick={onChipClick}
+                  closeButtonProps={{
+                    onClick: () => {
+                      onDeleteChip?.(chipProps?.key)
+                    },
+                    'aria-label': `Remove ${chipProps.key}`,
+                  }}
+                  {...{ [CHIP_ATTR_KEY]: chipProps?.key }}
+                  {...chipProps}
+                />
+              ))}
+            </InputChipList>
+          )}
+        </>
+      ),
       ...(onDeleteChipProp
         ? {
             onDeleteInputContent: () =>
@@ -502,6 +505,7 @@ function ComboBox({
     [
       chips,
       handleKeyDown,
+      inputContent,
       onDeleteChip,
       onDeleteChipProp,
       outerInputProps,
@@ -512,6 +516,7 @@ function ComboBox({
   return (
     <ComboBoxInner>
       <ComboBoxInput
+        inputRef={inputInnerRef}
         inputProps={{
           ...inputProps,
           onKeyDown: (e: KeyboardEvent<HTMLInputElement>) => {

--- a/src/components/TextSwitch.tsx
+++ b/src/components/TextSwitch.tsx
@@ -4,7 +4,6 @@ import {
   type ReactFragment,
   createContext,
   forwardRef,
-  useCallback,
   useContext,
   useEffect,
   useId,
@@ -55,6 +54,7 @@ const TextSwitchSC = styled.div<{ $size: TextSwitchSize }>(({ theme }) => ({
   color: theme.colors['text-light'],
 }))
 const SwitchSC = styled.div<{ $size: TextSwitchSize }>(({ theme, $size }) => ({
+  contain: 'paint',
   position: 'relative',
   display: 'flex',
   border: theme.borders.input,
@@ -125,7 +125,6 @@ function TextSwitch(
   )
 
   useLayoutEffect(() => {
-    console.log('outer', switchRef?.current)
     selectedElt.current = switchRef?.current?.querySelector(
       `[data-value="${value}"]`
     )
@@ -154,14 +153,13 @@ function TextSwitch(
   const state = useRadioGroupState(stateProps)
   const { radioGroupProps, labelProps } = useRadioGroup(stateProps, state)
 
-  console.log({ selectedLeft, selectedWidth })
   const springs = useSpring({
     to: { left: selectedLeft, width: selectedWidth },
     config: {
       clamp: true,
       mass: 0.6,
-      tension: 280,
-      velocity: 0.02,
+      tension: 420,
+      velocity: 0.1,
     },
   })
 
@@ -172,7 +170,9 @@ function TextSwitch(
       {...props}
       {...radioGroupProps}
     >
-      {label && labelPosition === 'start' && <div {...labelProps}>{label}</div>}
+      {label && labelPosition === 'start' && (
+        <LabelTextSC {...labelProps}>{label}</LabelTextSC>
+      )}
       <TextSwitchContext.Provider value={state}>
         <SwitchSC
           ref={switchRef}
@@ -193,17 +193,26 @@ function TextSwitch(
           />
         </SwitchSC>
       </TextSwitchContext.Provider>
-      {label && labelPosition === 'end' && <div {...labelProps}>{label}</div>}
+      {label && labelPosition === 'end' && (
+        <LabelTextSC {...labelProps}>{label}</LabelTextSC>
+      )}
     </TextSwitchSC>
   )
 }
 
+const LabelTextSC = styled.div(({ theme }) => ({
+  ...theme.partials.text.overline,
+  position: 'relative',
+  top: 0.5,
+}))
+
 const TextSwitchOptionSC = styled.label<{
   $size: TextSwitchSize
-  $isFocusVisible: boolean
   $disabled: boolean
-}>(({ $size, $disabled = false, $isFocusVisible, theme }) => ({
-  ...theme.partials.text.body2,
+}>(({ $size, $disabled = false, theme }) => ({
+  position: 'relative',
+  overflow: 'hidden',
+  whiteSpace: 'nowrap',
   display: 'flex',
   flexShrink: 0,
   flexGrow: 0,
@@ -217,6 +226,7 @@ const TextSwitchOptionSC = styled.label<{
   margin: 0,
   justifyContent: 'center',
   borderRadius: (sizeToHeight[$size] - 2) / 2,
+  transition: 'all 0.1s ease',
   '&::before': {
     position: 'absolute',
     content: '""',
@@ -227,6 +237,12 @@ const TextSwitchOptionSC = styled.label<{
     zIndex: -1,
     backgroundColor: 'transparent',
   },
+  '&:not(:last-of-type)': {
+    marginRight: -2,
+  },
+  '&:not(:first-of-type)': {
+    marginRight: -2,
+  },
   ':focus': {
     outline: 'none',
   },
@@ -234,7 +250,7 @@ const TextSwitchOptionSC = styled.label<{
     ? {
         '&:hover': {
           color: theme.colors.text,
-          ':not(.selected)': {
+          '&::before': {
             backgroundColor: theme.colors['action-input-hover'],
           },
           '.icon': {
@@ -243,9 +259,6 @@ const TextSwitchOptionSC = styled.label<{
         },
         '&.selected': {
           color: theme.colors['action-always-white'],
-          '&::before': {
-            backgroundColor: 'transparent',
-          },
         },
       }
     : {
@@ -255,7 +268,7 @@ const TextSwitchOptionSC = styled.label<{
       }),
 }))
 
-export type RadioProps = AriaRadioProps & {
+export type TextSwitchOptionProps = AriaRadioProps & {
   size?: 'small'
   disabled?: boolean
   defaultSelected?: boolean
@@ -279,7 +292,7 @@ function TextSwitchOption({
   name,
   label,
   ...props
-}: RadioProps) {
+}: TextSwitchOptionProps) {
   const [selected, setSelected] = useState(defaultSelected || selectedProp)
   const state = useContext(TextSwitchContext) || {
     setSelectedValue: () => {},
@@ -292,7 +305,7 @@ function TextSwitchOption({
 
   const labelId = useId()
   const inputRef = useRef<any>()
-  const { isFocusVisible, focusProps } = useFocusRing()
+  const { focusProps } = useFocusRing()
   const { inputProps, isSelected, isDisabled } = useRadio(
     {
       value,
@@ -312,9 +325,7 @@ function TextSwitchOption({
     <TextSwitchOptionSC
       htmlFor={inputProps.id}
       id={labelId}
-      //   ref={ref}
       className={classNames({ selected: isSelected })}
-      $isFocusVisible={isFocusVisible}
       $size={size}
       $disabled={isDisabled}
       data-value={value}
@@ -335,7 +346,7 @@ function TextSwitchOption({
           ref={inputRef}
         />
       </VisuallyHidden>
-      <div className="label">{label}</div>
+      <LabelTextSC className="label">{label}</LabelTextSC>
     </TextSwitchOptionSC>
   )
 }

--- a/src/components/TextSwitch.tsx
+++ b/src/components/TextSwitch.tsx
@@ -20,16 +20,16 @@ import {
 import { useRadioGroupState } from 'react-stately'
 
 import classNames from 'classnames'
-import styled from 'styled-components'
+import styled, {
+  type DefaultTheme,
+  type StyledComponent,
+} from 'styled-components'
 import { VisuallyHidden, useFocusRing } from 'react-aria'
 import { type ComponentPropsWithRef, useSpring } from '@react-spring/web'
 
-import { AnimatedDiv } from './AnimatedDiv'
+import { type SetRequired } from 'type-fest'
 
-const sizeToHeight = { small: 20 } as const satisfies Record<
-  TextSwitchSize,
-  number
->
+import { AnimatedDiv } from './AnimatedDiv'
 
 type TextSwitchSize = 'small'
 type TextSwitchOption = { value: string } & (
@@ -41,10 +41,19 @@ type TextSwitchOption = { value: string } & (
 )
 type TextSwitchOptions = TextSwitchOption[]
 
-type TextSwitchProps = Omit<AriaRadioGroupProps, 'orientation'> & {
+type TextSwitchProps = SetRequired<
+  Omit<AriaRadioGroupProps, 'orientation'>,
+  'value'
+> & {
+  size: TextSwitchSize
   options: TextSwitchOptions
-  labelPosition: 'start' | 'end'
-} & ComponentPropsWithRef<typeof TextSwitchSC>
+  labelPosition?: 'start' | 'end'
+} & ComponentPropsWithRef<StyledComponent<'div', DefaultTheme>>
+
+const sizeToHeight = { small: 22 } as const satisfies Record<
+  TextSwitchSize,
+  number
+>
 
 const TextSwitchSC = styled.div<{ $size: TextSwitchSize }>(({ theme }) => ({
   display: 'flex',
@@ -213,12 +222,13 @@ const TextSwitchOptionSC = styled.label<{
   position: 'relative',
   overflow: 'hidden',
   whiteSpace: 'nowrap',
+  userSelect: 'none',
   display: 'flex',
   flexShrink: 0,
   flexGrow: 0,
   gap: theme.spacing.small,
   alignItems: 'center',
-  padding: `${0} ${6}px`,
+  padding: `${0} ${8}px`,
   color: $disabled
     ? theme.colors['text-input-disabled']
     : theme.colors['text-xlight'],

--- a/src/stories/ClusterTagsTemplate.tsx
+++ b/src/stories/ClusterTagsTemplate.tsx
@@ -4,11 +4,12 @@ import Fuse from 'fuse.js'
 
 import { isEqual, uniqWith } from 'lodash-es'
 
-import styled from 'styled-components'
+import styled, { useTheme } from 'styled-components'
 
 import { Card, Chip, ComboBox, ListBoxItem, TagIcon, WrapWithIf } from '..'
 
 import { isNonNullable } from '../utils/isNonNullable'
+import TextSwitch from '../components/TextSwitch'
 
 const TagPicker = styled.div(({ theme }) => ({
   display: 'flex',
@@ -51,10 +52,12 @@ export function ClusterTagsTemplate({
   onFillLevel: any
   withTitleContent: boolean
 }) {
+  const theme = useTheme()
   const [selectedTagKeys, setSelectedTagKeys] = useState(new Set<Key>())
   const selectedTagArr = useMemo(() => [...selectedTagKeys], [selectedTagKeys])
   const [inputValue, setInputValue] = useState('')
   const [isOpen, setIsOpen] = useState(false)
+  const [searchLogic, setSearchLogic] = useState<string>('AND')
 
   const fuse = useMemo(
     () =>
@@ -117,6 +120,23 @@ export function ClusterTagsTemplate({
             inputValue={inputValue}
             onSelectionChange={onSelectionChange}
             onInputChange={onInputChange}
+            inputContent={
+              selectedTagArr.length > -1 && (
+                <TextSwitch
+                  onClick={(e: MouseEvent) => e.stopPropagation()}
+                  size="small"
+                  value={searchLogic}
+                  onChange={setSearchLogic}
+                  options={[
+                    { label: 'All', value: 'AND' },
+                    { label: 'Any', value: 'OR' },
+                  ]}
+                  css={{ marginRight: theme.spacing.xxsmall }}
+                  label="Match"
+                  labelPosition="start"
+                />
+              )
+            }
             chips={selectedTagArr.map((key) => ({
               key,
               children: key,
@@ -135,6 +155,7 @@ export function ClusterTagsTemplate({
             }}
             maxHeight={232}
             allowsEmptyCollection
+            startIcon={<TagIcon />}
             {...(withTitleContent
               ? {
                   startIcon: null,

--- a/src/stories/TextSwitch.stories.tsx
+++ b/src/stories/TextSwitch.stories.tsx
@@ -1,14 +1,17 @@
 import { type ComponentProps, useState } from 'react'
-import { useTheme } from 'styled-components'
-
 import { Flex } from 'honorable'
 
-import Button from '../components/Button'
 import TextSwitch from '../components/TextSwitch'
 
 export default {
   title: 'TextSwitch',
   component: TextSwitch,
+  argTypes: {
+    size: {
+      options: ['small'],
+      control: { type: 'select' },
+    },
+  },
 }
 
 const options1 = [
@@ -24,19 +27,19 @@ const options1 = [
 const options2 = [
   {
     value: '0',
-    label: '1',
+    label: 'one',
   },
   {
     value: '1',
-    label: '2',
+    label: 'two',
   },
   {
     value: '2',
-    label: '3',
+    label: 'three',
   },
   {
     value: '3',
-    label: '4',
+    label: 'four',
   },
 ] as const satisfies ComponentProps<typeof TextSwitch>['options']
 
@@ -54,16 +57,16 @@ function Template({ label, ...args }: ComponentProps<typeof TextSwitch>) {
       flexDirection="column"
     >
       <TextSwitch
-        name="radio-group-controlled"
-        label={label || 'Match:'}
+        name="radio-group-controlled1"
+        label={label || 'Match'}
         value={selectedValue1}
         onChange={setSelectedValue1}
         options={options1}
         {...args}
       />
       <TextSwitch
-        name="radio-group-controlled"
-        label={label || 'Tabs'}
+        name="radio-group-controlled2"
+        label={label || 'Options'}
         labelPosition="end"
         value={selectedValue2}
         onChange={setSelectedValue2}
@@ -74,8 +77,8 @@ function Template({ label, ...args }: ComponentProps<typeof TextSwitch>) {
   )
 }
 
-export const Small = Template.bind({})
-Small.args = {
+export const Default = Template.bind({})
+Default.args = {
   size: 'small',
   label: '',
   isDisabled: false,

--- a/src/stories/TextSwitch.stories.tsx
+++ b/src/stories/TextSwitch.stories.tsx
@@ -1,0 +1,82 @@
+import { type ComponentProps, useState } from 'react'
+import { useTheme } from 'styled-components'
+
+import { Flex } from 'honorable'
+
+import Button from '../components/Button'
+import TextSwitch from '../components/TextSwitch'
+
+export default {
+  title: 'TextSwitch',
+  component: TextSwitch,
+}
+
+const options1 = [
+  {
+    value: 'AND',
+    label: 'All',
+  },
+  {
+    value: 'OR',
+    label: 'Any',
+  },
+] as const satisfies ComponentProps<typeof TextSwitch>['options']
+const options2 = [
+  {
+    value: '0',
+    label: '1',
+  },
+  {
+    value: '1',
+    label: '2',
+  },
+  {
+    value: '2',
+    label: '3',
+  },
+  {
+    value: '3',
+    label: '4',
+  },
+] as const satisfies ComponentProps<typeof TextSwitch>['options']
+
+function Template({ label, ...args }: ComponentProps<typeof TextSwitch>) {
+  const [selectedValue1, setSelectedValue1] = useState<string>(
+    'AND' satisfies (typeof options1)[number]['value']
+  )
+  const [selectedValue2, setSelectedValue2] = useState<string>(
+    '0' satisfies (typeof options2)[number]['value']
+  )
+
+  return (
+    <Flex
+      gap="medium"
+      flexDirection="column"
+    >
+      <TextSwitch
+        name="radio-group-controlled"
+        label={label || 'Match:'}
+        value={selectedValue1}
+        onChange={setSelectedValue1}
+        options={options1}
+        {...args}
+      />
+      <TextSwitch
+        name="radio-group-controlled"
+        label={label || 'Tabs'}
+        labelPosition="end"
+        value={selectedValue2}
+        onChange={setSelectedValue2}
+        options={options2}
+        {...args}
+      />
+    </Flex>
+  )
+}
+
+export const Small = Template.bind({})
+Small.args = {
+  size: 'small',
+  label: '',
+  isDisabled: false,
+} as const satisfies Partial<ComponentProps<typeof TextSwitch>>


### PR DESCRIPTION
Add new `TextSwitch` to be used inside `ComboBox` for configuration search filtering.
## TextSwitch
<img width="333" alt="Screenshot 2024-01-22 at 4 31 25 PM" src="https://github.com/pluralsh/design-system/assets/85062/9a60eea9-d1fa-48a5-8d8d-89c06d22e7e5">

<img width="313" alt="Screenshot 2024-01-22 at 4 31 33 PM" src="https://github.com/pluralsh/design-system/assets/85062/b8b2fae0-621d-4133-94f5-a6c2064e1df4">

### In combo box
<img width="563" alt="Screenshot 2024-01-22 at 4 31 16 PM" src="https://github.com/pluralsh/design-system/assets/85062/2c4caaab-88a5-4b06-ac5e-f9860b4186e1">

<img width="551" alt="Screenshot 2024-01-22 at 4 31 05 PM" src="https://github.com/pluralsh/design-system/assets/85062/2f94b731-4368-404a-8d18-c0f9902eb355">
