### PR TITLE
feat: Helpers for interactive table elements

### DIFF
--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -42,6 +42,7 @@ import ArrowRightIcon from './icons/ArrowRightIcon'
 import { FillLevelProvider } from './contexts/FillLevelContext'
 import EmptyState from './EmptyState'
 import { Spinner } from './Spinner'
+import { tableInteractiveTargetingProp } from './TableInteractive'
 
 export type TableProps = Omit<
   DivProps,
@@ -173,26 +174,31 @@ const Tr = styled.tr<{
     $lighter: lighter = false,
     $selectable: selectable = false,
     $selected: selected = false,
-  }) => ({
-    display: 'contents',
-    backgroundColor: selected
+  }) => {
+    const defaultBGColor = selected
       ? theme.colors['fill-one-selected']
       : lighter || (selectable && !selected)
       ? theme.colors['fill-one']
-      : theme.colors['fill-one-hover'],
+      : theme.colors['fill-one-hover']
 
-    ...(clickable && {
-      cursor: 'pointer',
-
-      '&:hover': {
-        backgroundColor: selectable
-          ? selected
-            ? theme.colors['fill-one-selected']
-            : theme.colors['fill-one-hover']
-          : theme.colors['fill-one-selected'],
-      },
-    }),
-  })
+    return {
+      display: 'contents',
+      backgroundColor: defaultBGColor,
+      ...(clickable && {
+        cursor: 'pointer',
+        '&:hover': {
+          backgroundColor: selectable
+            ? selected
+              ? theme.colors['fill-one-selected']
+              : theme.colors['fill-one-hover']
+            : theme.colors['fill-one-selected'],
+          [`&:has([${tableInteractiveTargetingProp}]:hover)`]: {
+            backgroundColor: defaultBGColor,
+          },
+        },
+      }),
+    }
+  }
 )
 
 const Th = styled.th<{

--- a/src/components/TableInteractive.tsx
+++ b/src/components/TableInteractive.tsx
@@ -1,0 +1,14 @@
+export const tableInteractiveTargetingProp =
+  'data-plural-table-interactive' as const
+
+export function TableInteractive({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      {...{ [tableInteractiveTargetingProp]: '' }}
+      style={{ display: 'contents' }}
+      onClick={(e) => e.stopPropagation()}
+    >
+      {children}
+    </div>
+  )
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,6 +60,7 @@ export type { TabListStateProps, TabBaseProps } from './components/TabList'
 export { TabList } from './components/TabList'
 export { default as TabPanel } from './components/TabPanel'
 export { default as Table } from './components/Table'
+export { TableInteractive } from './components/TableInteractive'
 export { default as TipCarousel } from './components/TipCarousel'
 export {
   type ValidationResponse,

--- a/src/stories/Table.stories.tsx
+++ b/src/stories/Table.stories.tsx
@@ -15,11 +15,13 @@ import { useTheme } from 'styled-components'
 import {
   AppIcon,
   ArrowRightLeftIcon,
+  Button,
   CollapseIcon,
   IconFrame,
   InfoIcon,
   LogsIcon,
   Table,
+  TableInteractive,
   Tooltip,
 } from '..'
 
@@ -204,6 +206,25 @@ const expandingColumns = [
     id: 'description',
     cell: (info: any) => <span>{info.getValue()}</span>,
     header: () => <span>Description</span>,
+  }),
+]
+
+const clickableColumns = [
+  columns[0],
+  columns[columns.length - 1],
+  columnHelper.display({
+    id: 'actions',
+    cell: () => (
+      <TableInteractive>
+        <Button
+          secondary
+          clickable
+          onClick={() => console.info('Button clicked')}
+        >
+          Row shouldn't highlight on hover
+        </Button>
+      </TableInteractive>
+    ),
   }),
 ]
 
@@ -402,8 +423,9 @@ Clickable.args = {
   width: '900px',
   height: '400px',
   data: repeatedData,
-  columns: expandingColumns,
-  onRowClick: (e: MouseEvent, row: Row<any>) => console.info(row?.original),
+  columns: clickableColumns,
+  onRowClick: (e: MouseEvent, row: Row<any>) =>
+    console.info(`Row clicked: ${row?.original.function}`),
 }
 
 export const StickyColumn = Template.bind({})


### PR DESCRIPTION
Add a `TableInteractive` wrapper component that prevents clicks on its children from triggering `onRowClick` for a `Table`. To make it more clear when clicking a row will or will not trigger `onRowClick`, this also adds styling to make sure clickable rows are not highlighted when hovering over `TableInteractive`'s children.