### PR TITLE
fix: Parts of elements appear above the Modal actions area when scrolling

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -88,6 +88,8 @@ const ModalContentSC = styled.div<{
   $scrollable: boolean
   $hasActions: boolean
 }>(({ theme, $scrollable, $hasActions }) => ({
+  position: 'relative',
+  zIndex: 0,
   margin: theme.spacing.large,
   marginBottom: $hasActions ? 0 : theme.spacing.large,
   ...theme.partials.text.body1,

--- a/src/stories/Modal.stories.tsx
+++ b/src/stories/Modal.stories.tsx
@@ -1,9 +1,9 @@
-import { Div, H3, P } from 'honorable'
+import { Div, Flex, H3, P } from 'honorable'
 import { useState } from 'react'
 
 import styled from 'styled-components'
 
-import { Button, Card, Code, FormField, Input, Modal } from '..'
+import { Button, Card, Code, FormField, Input2, Modal, SearchIcon } from '..'
 import { SEVERITIES } from '../components/Modal'
 import { jsCode } from '../constants'
 
@@ -104,26 +104,18 @@ function Template(args: any) {
         )}
 
         {args.form && (
-          <>
-            <FormField
-              marginBottom="medium"
-              label="Name"
-            >
-              <Input value="Admin" />
+          <Flex
+            gap="medium"
+            direction="column"
+          >
+            <FormField label="Name">
+              <Input2 value="Admin" />
             </FormField>
-
-            <FormField
-              marginBottom="medium"
-              label="Description"
-            >
-              <Input value="Full account access" />
+            <FormField label="Description">
+              <Input2 value="Full account access" />
             </FormField>
-
-            <FormField
-              marginBottom="medium"
-              label="Repository bindings"
-            >
-              <Input value="*" />
+            <FormField label="Repository bindings">
+              <Input2 value="*" />
             </FormField>
             <P>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus
@@ -138,7 +130,10 @@ function Template(args: any) {
               interdum, placerat dolor. Pellentesque et semper massa. Aliquam
               nec nisl eu nibh fringilla vehicula. Suspendisse a purus quam.
             </P>
-          </>
+            <FormField label="Repository bindings">
+              <Input2 startIcon={<SearchIcon />} />
+            </FormField>
+          </Flex>
         )}
       </Modal>
       <Card
@@ -247,21 +242,21 @@ function PinnedToTopTemplate(args: any) {
               marginBottom="medium"
               label="Name"
             >
-              <Input value="Admin" />
+              <Input2 value="Admin" />
             </FormField>
 
             <FormField
               marginBottom="medium"
               label="Description"
             >
-              <Input value="Full account access" />
+              <Input2 value="Full account access" />
             </FormField>
 
             <FormField
               marginBottom="medium"
               label="Repository bindings"
             >
-              <Input value="*" />
+              <Input2 value="*" />
             </FormField>
             <P>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus


### PR DESCRIPTION
### Before
Icon in `Input` element showing above actions background
<img width="630" alt="Screenshot 2024-03-08 at 11 48 26 AM" src="https://github.com/pluralsh/design-system/assets/85062/9f0ede5f-6fa9-4383-b0dd-06c373d3beec">

### After
Icon is now properly blocked by actions background
<img width="631" alt="Screenshot 2024-03-08 at 11 48 54 AM" src="https://github.com/pluralsh/design-system/assets/85062/e9e70222-008f-4851-9fae-92e1afd63ddb">
