### PR TITLE
feat: create component for tag multi select with new design

### DIFF
--- a/src/components/ComboBox.tsx
+++ b/src/components/ComboBox.tsx
@@ -67,6 +67,7 @@ type ComboBoxProps = Exclude<ComboBoxInputProps, 'children'> & {
   onDeleteChip?: (key: string) => void
   inputContent?: ComponentProps<typeof Input2>['inputContent']
   onDeleteInputContent?: ComponentProps<typeof Input2>['onDeleteInputContent']
+  containerProps?: HTMLAttributes<HTMLDivElement>
 } & Pick<InputProps, 'suffix' | 'prefix' | 'titleContent' | 'showClearButton'> &
   Omit<
     ComboBoxStateOptions<object>,
@@ -251,6 +252,7 @@ function ComboBox({
   chips,
   inputContent,
   onDeleteChip: onDeleteChipProp,
+  containerProps,
   ...props
 }: ComboBoxProps) {
   const nextFocusedKeyRef = useRef<Key>(null)
@@ -514,7 +516,7 @@ function ComboBox({
   )
 
   return (
-    <ComboBoxInner>
+    <ComboBoxInner {...containerProps}>
       <ComboBoxInput
         inputRef={inputInnerRef}
         inputProps={{

--- a/src/components/TagMultiSelect.tsx
+++ b/src/components/TagMultiSelect.tsx
@@ -1,0 +1,181 @@
+import { Flex } from 'honorable'
+import {
+  type ComponentProps,
+  type Key,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react'
+import Fuse from 'fuse.js'
+
+import { useTheme } from 'styled-components'
+
+import { Chip, ComboBox, ListBoxItem, Select, SelectButton } from '..'
+
+import { isNonNullable } from '../utils/isNonNullable'
+
+export type MultiSelectTag = {
+  name: string
+  value: string
+}
+
+function tagToKey(tag: MultiSelectTag) {
+  return `${tag.name}:${tag.value}`
+}
+const matchOptions = [
+  { label: 'All', value: 'AND' },
+  { label: 'Any', value: 'OR' },
+]
+
+export function TagMultiSelect({
+  tags,
+  loading,
+  onChange,
+}: {
+  tags: MultiSelectTag[]
+  loading: boolean
+  onChange?: (keys: Set<Key>) => void
+}) {
+  const theme = useTheme()
+  const [selectedTagKeys, setSelectedTagKeys] = useState(new Set<Key>())
+  const selectedTagArr = useMemo(() => [...selectedTagKeys], [selectedTagKeys])
+  const [inputValue, setInputValue] = useState('')
+  const [isOpen, setIsOpen] = useState(false)
+  const [searchLogic, setSearchLogic] = useState<string>(matchOptions[0].value)
+
+  const fuse = useMemo(
+    () =>
+      new Fuse(tags, {
+        includeScore: true,
+        shouldSort: true,
+        threshold: 0.3,
+        keys: ['name', 'value'],
+      }),
+    [tags]
+  )
+
+  const searchResults = useMemo(() => {
+    let ret: Fuse.FuseResult<MultiSelectTag>[]
+
+    if (inputValue) {
+      ret = fuse.search(inputValue)
+    } else {
+      ret = tags.map((tag, i) => ({ item: tag, score: 1, refIndex: i }))
+    }
+
+    return ret.filter((tag) => !selectedTagKeys.has(tagToKey(tag.item)))
+  }, [fuse, inputValue, selectedTagKeys, tags])
+
+  const onSelectionChange: ComponentProps<
+    typeof ComboBox
+  >['onSelectionChange'] = (key) => {
+    if (key) {
+      setSelectedTagKeys(new Set([...selectedTagArr, key]))
+      setInputValue('')
+    }
+  }
+
+  useEffect(() => {
+    onChange?.(selectedTagKeys)
+  }, [selectedTagKeys, onChange])
+
+  const onInputChange: ComponentProps<typeof ComboBox>['onInputChange'] = (
+    value
+  ) => {
+    setInputValue(value)
+  }
+
+  return (
+    <Flex
+      flexDirection="row"
+      width="100%"
+    >
+      <Select
+        label="Pick search logic"
+        selectedKey={searchLogic}
+        onSelectionChange={(key: string) => {
+          setSearchLogic(key)
+        }}
+        defaultOpen={false}
+        triggerButton={
+          <SelectButton
+            css={{
+              borderTopRightRadius: 0,
+              borderBottomRightRadius: 0,
+              borderRight: `none`,
+              width: '150px',
+            }}
+          >
+            Match {matchOptions.find((el) => el.value === searchLogic).label}
+          </SelectButton>
+        }
+      >
+        {matchOptions.map(({ value, label }) => (
+          <ListBoxItem
+            key={value}
+            label={label}
+            textValue={label}
+          />
+        ))}
+      </Select>
+      <ComboBox
+        isOpen={isOpen}
+        startIcon={null}
+        inputValue={inputValue}
+        onSelectionChange={onSelectionChange}
+        onInputChange={onInputChange}
+        chips={selectedTagArr.map((key) => ({
+          key,
+          children: key,
+        }))}
+        onDeleteChip={(chipKey) => {
+          const newKeys = new Set(selectedTagKeys)
+
+          newKeys.delete(chipKey)
+          setSelectedTagKeys(newKeys)
+        }}
+        inputProps={{
+          placeholder: 'Search Tags...',
+          style: {
+            borderTopLeftRadius: 0,
+            borderBottomLeftRadius: 0,
+            backgroundColor: theme.colors['fill-one'],
+          },
+        }}
+        onOpenChange={(isOpen, _trigger) => {
+          setIsOpen(isOpen)
+        }}
+        maxHeight={232}
+        allowsEmptyCollection
+        loading={loading}
+        containerProps={{ style: { flexGrow: 1 } }}
+      >
+        {searchResults
+          .map(({ item: tag, score: _score, refIndex: _refIndex }) => {
+            const tagStr = tagToKey(tag)
+
+            if (selectedTagKeys.has(tagStr)) {
+              return null
+            }
+
+            return (
+              <ListBoxItem
+                key={tagStr}
+                label={
+                  <Chip
+                    size="small"
+                    label={tagStr}
+                    textValue={tagStr}
+                  >
+                    {tagStr}
+                  </Chip>
+                }
+                textValue={tagStr}
+              />
+            )
+          })
+          .filter(isNonNullable)}
+      </ComboBox>
+    </Flex>
+  )
+}

--- a/src/components/TagMultiSelect.tsx
+++ b/src/components/TagMultiSelect.tsx
@@ -6,7 +6,6 @@ import {
   useMemo,
   useState,
 } from 'react'
-import Fuse from 'fuse.js'
 
 import { useTheme } from 'styled-components'
 
@@ -19,21 +18,18 @@ export type MultiSelectTag = {
   value: string
 }
 
-function tagToKey(tag: MultiSelectTag) {
-  return `${tag.name}:${tag.value}`
-}
 const matchOptions = [
   { label: 'All', value: 'AND' },
   { label: 'Any', value: 'OR' },
 ]
 
 export function TagMultiSelect({
-  tags,
+  options,
   loading,
   onSelectedTagsChange,
   onFilterChange,
 }: {
-  tags: MultiSelectTag[]
+  options: string[]
   loading: boolean
   onSelectedTagsChange?: (keys: Set<Key>) => void
   onFilterChange?: (value: string) => void
@@ -44,29 +40,6 @@ export function TagMultiSelect({
   const [inputValue, setInputValue] = useState('')
   const [isOpen, setIsOpen] = useState(false)
   const [searchLogic, setSearchLogic] = useState<string>(matchOptions[0].value)
-
-  const fuse = useMemo(
-    () =>
-      new Fuse(tags, {
-        includeScore: true,
-        shouldSort: true,
-        threshold: 0.3,
-        keys: ['name', 'value'],
-      }),
-    [tags]
-  )
-
-  const searchResults = useMemo(() => {
-    let ret: Fuse.FuseResult<MultiSelectTag>[]
-
-    if (inputValue) {
-      ret = fuse.search(inputValue)
-    } else {
-      ret = tags.map((tag, i) => ({ item: tag, score: 1, refIndex: i }))
-    }
-
-    return ret.filter((tag) => !selectedTagKeys.has(tagToKey(tag.item)))
-  }, [fuse, inputValue, selectedTagKeys, tags])
 
   const onSelectionChange: ComponentProps<
     typeof ComboBox
@@ -156,10 +129,8 @@ export function TagMultiSelect({
         loading={loading}
         containerProps={{ style: { flexGrow: 1 } }}
       >
-        {searchResults
-          .map(({ item: tag, score: _score, refIndex: _refIndex }) => {
-            const tagStr = tagToKey(tag)
-
+        {options
+          .map((tagStr) => {
             if (selectedTagKeys.has(tagStr)) {
               return null
             }

--- a/src/components/TagMultiSelect.tsx
+++ b/src/components/TagMultiSelect.tsx
@@ -30,11 +30,13 @@ const matchOptions = [
 export function TagMultiSelect({
   tags,
   loading,
-  onChange,
+  onSelectedTagsChange,
+  onFilterChange,
 }: {
   tags: MultiSelectTag[]
   loading: boolean
-  onChange?: (keys: Set<Key>) => void
+  onSelectedTagsChange?: (keys: Set<Key>) => void
+  onFilterChange?: (value: string) => void
 }) {
   const theme = useTheme()
   const [selectedTagKeys, setSelectedTagKeys] = useState(new Set<Key>())
@@ -76,8 +78,12 @@ export function TagMultiSelect({
   }
 
   useEffect(() => {
-    onChange?.(selectedTagKeys)
-  }, [selectedTagKeys, onChange])
+    onSelectedTagsChange?.(selectedTagKeys)
+  }, [selectedTagKeys, onSelectedTagsChange])
+
+  useEffect(() => {
+    onFilterChange?.(inputValue)
+  }, [inputValue, onFilterChange])
 
   const onInputChange: ComponentProps<typeof ComboBox>['onInputChange'] = (
     value

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,6 +103,7 @@ export type {
 export { default as LoadingSpinner } from './components/LoadingSpinner'
 export { default as LoopingLogo } from './components/LoopingLogo'
 export { ComboBox } from './components/ComboBox'
+export { TagMultiSelect } from './components/TagMultiSelect'
 export { Toast, GraphQLToast } from './components/Toast'
 export { default as WrapWithIf } from './components/WrapWithIf'
 export type {

--- a/src/stories/ComboBox.stories.tsx
+++ b/src/stories/ComboBox.stories.tsx
@@ -511,7 +511,7 @@ const tags = uniqWith(TAGS, isEqual)
 export const TagMultiSelect = TagMultiSelectTemplate.bind({})
 TagMultiSelect.args = {
   loading: false,
-  tags,
+  options: tags.map((tag) => `${tag.name}:${tag.value}`),
   width: 100,
   onSelectedTagsChange: (keys: Set<Key>) => {
     console.log('Selected keys:', keys)

--- a/src/stories/ComboBox.stories.tsx
+++ b/src/stories/ComboBox.stories.tsx
@@ -3,6 +3,8 @@ import { type ComponentProps, type Key, useMemo, useState } from 'react'
 import styled from 'styled-components'
 import Fuse from 'fuse.js'
 
+import { isEqual, uniqWith } from 'lodash-es'
+
 import {
   AppIcon,
   BrowseAppsIcon,
@@ -12,8 +14,11 @@ import {
   ListBoxFooterPlus,
   ListBoxItem,
   ListBoxItemChipList,
+  TagMultiSelect,
   WrapWithIf,
 } from '..'
+
+import { type MultiSelectTag } from '../components/TagMultiSelect'
 
 import { ClusterTagsTemplate } from './ClusterTagsTemplate'
 
@@ -485,4 +490,54 @@ export const ClusterTags = ClusterTagsTemplate.bind({})
 ClusterTags.args = {
   loading: false,
   withTitleContent: false,
+}
+
+const TAGS = [
+  { name: 'local', value: 'true' },
+  { name: 'local', value: 'false' },
+  { name: 'stage', value: 'dev' },
+  { name: 'stage', value: 'prod' },
+  { name: 'stage', value: 'canary' },
+  { name: 'route', value: 'some-very-very-long-tag-value' },
+  { name: 'route', value: 'short-name' },
+  { name: 'local2', value: 'true' },
+  { name: 'local2', value: 'false' },
+  { name: 'stage2', value: 'dev' },
+  { name: 'stage2', value: 'prod' },
+  { name: 'stage2', value: 'canary' },
+  { name: 'route2', value: 'some-very-very-long-tag-value' },
+  { name: 'route2', value: 'short-name' },
+]
+const tags = uniqWith(TAGS, isEqual)
+
+function TagMultiSelectTemplate({
+  loading,
+  tags,
+  width,
+  onChange,
+}: {
+  loading: boolean
+  tags: MultiSelectTag[]
+  width: number
+  onChange?: (keys: Set<Key>) => void
+}) {
+  return (
+    <div style={{ width: `${width}%` }}>
+      <TagMultiSelect
+        loading={loading}
+        tags={tags}
+        onChange={onChange}
+      />
+    </div>
+  )
+}
+
+export const TagMultiSelectStory = TagMultiSelectTemplate.bind({})
+TagMultiSelectStory.args = {
+  loading: false,
+  tags,
+  width: 100,
+  onChange: (keys: Set<Key>) => {
+    console.log('Selected keys:', keys)
+  },
 }

--- a/src/stories/ComboBox.stories.tsx
+++ b/src/stories/ComboBox.stories.tsx
@@ -14,13 +14,11 @@ import {
   ListBoxFooterPlus,
   ListBoxItem,
   ListBoxItemChipList,
-  TagMultiSelect,
   WrapWithIf,
 } from '..'
 
-import { type MultiSelectTag } from '../components/TagMultiSelect'
-
 import { ClusterTagsTemplate } from './ClusterTagsTemplate'
+import TagMultiSelectTemplate from './TagMultiselectTemplate'
 
 export default {
   title: 'Combo Box',
@@ -510,30 +508,8 @@ const TAGS = [
 ]
 const tags = uniqWith(TAGS, isEqual)
 
-function TagMultiSelectTemplate({
-  loading,
-  tags,
-  width,
-  onChange,
-}: {
-  loading: boolean
-  tags: MultiSelectTag[]
-  width: number
-  onChange?: (keys: Set<Key>) => void
-}) {
-  return (
-    <div style={{ width: `${width}%` }}>
-      <TagMultiSelect
-        loading={loading}
-        tags={tags}
-        onSelectedTagsChange={onChange}
-      />
-    </div>
-  )
-}
-
-export const TagMultiSelectStory = TagMultiSelectTemplate.bind({})
-TagMultiSelectStory.args = {
+export const TagMultiSelect = TagMultiSelectTemplate.bind({})
+TagMultiSelect.args = {
   loading: false,
   tags,
   width: 100,

--- a/src/stories/ComboBox.stories.tsx
+++ b/src/stories/ComboBox.stories.tsx
@@ -526,7 +526,7 @@ function TagMultiSelectTemplate({
       <TagMultiSelect
         loading={loading}
         tags={tags}
-        onChange={onChange}
+        onSelectedTagsChange={onChange}
       />
     </div>
   )

--- a/src/stories/ComboBox.stories.tsx
+++ b/src/stories/ComboBox.stories.tsx
@@ -513,7 +513,10 @@ TagMultiSelect.args = {
   loading: false,
   tags,
   width: 100,
-  onChange: (keys: Set<Key>) => {
+  onSelectedTagsChange: (keys: Set<Key>) => {
     console.log('Selected keys:', keys)
+  },
+  onFilterChange: (filter: string) => {
+    console.log('Filter:', filter)
   },
 }

--- a/src/stories/TagMultiselectTemplate.tsx
+++ b/src/stories/TagMultiselectTemplate.tsx
@@ -1,19 +1,16 @@
 import { type Key } from 'react'
 
-import {
-  type MultiSelectTag,
-  TagMultiSelect,
-} from '../components/TagMultiSelect'
+import { TagMultiSelect } from '../components/TagMultiSelect'
 
 export default function TagMultiSelectTemplate({
   loading,
-  tags,
+  options,
   width,
   onSelectedTagsChange,
   onFilterChange,
 }: {
   loading: boolean
-  tags: MultiSelectTag[]
+  options: string[]
   width: number
   onSelectedTagsChange?: (keys: Set<Key>) => void
   onFilterChange?: (value: string) => void
@@ -22,7 +19,7 @@ export default function TagMultiSelectTemplate({
     <div style={{ width: `${width}%` }}>
       <TagMultiSelect
         loading={loading}
-        tags={tags}
+        options={options}
         onSelectedTagsChange={onSelectedTagsChange}
         onFilterChange={onFilterChange}
       />

--- a/src/stories/TagMultiselectTemplate.tsx
+++ b/src/stories/TagMultiselectTemplate.tsx
@@ -1,0 +1,28 @@
+import { type Key } from 'react'
+
+import {
+  type MultiSelectTag,
+  TagMultiSelect,
+} from '../components/TagMultiSelect'
+
+export default function TagMultiSelectTemplate({
+  loading,
+  tags,
+  width,
+  onChange,
+}: {
+  loading: boolean
+  tags: MultiSelectTag[]
+  width: number
+  onChange?: (keys: Set<Key>) => void
+}) {
+  return (
+    <div style={{ width: `${width}%` }}>
+      <TagMultiSelect
+        loading={loading}
+        tags={tags}
+        onSelectedTagsChange={onChange}
+      />
+    </div>
+  )
+}

--- a/src/stories/TagMultiselectTemplate.tsx
+++ b/src/stories/TagMultiselectTemplate.tsx
@@ -9,19 +9,22 @@ export default function TagMultiSelectTemplate({
   loading,
   tags,
   width,
-  onChange,
+  onSelectedTagsChange,
+  onFilterChange,
 }: {
   loading: boolean
   tags: MultiSelectTag[]
   width: number
-  onChange?: (keys: Set<Key>) => void
+  onSelectedTagsChange?: (keys: Set<Key>) => void
+  onFilterChange?: (value: string) => void
 }) {
   return (
     <div style={{ width: `${width}%` }}>
       <TagMultiSelect
         loading={loading}
         tags={tags}
-        onSelectedTagsChange={onChange}
+        onSelectedTagsChange={onSelectedTagsChange}
+        onFilterChange={onFilterChange}
       />
     </div>
   )


### PR DESCRIPTION
![image](https://github.com/pluralsh/design-system/assets/38671115/333697e3-a884-4c48-b5de-1ad62349472b)

I left the filtering for the parent component because the logic in cluster is too specific and it requires refetches with different arguments. 
