### PR TITLE
fix: pointer events under arrow scroll

### DIFF
--- a/src/components/ArrowScroll.tsx
+++ b/src/components/ArrowScroll.tsx
@@ -47,6 +47,7 @@ const ArrowWrapperSC = styled.div<{
   },
   '&.hidden': {
     opacity: 0,
+    pointerEvents: 'none',
   },
 }))
 


### PR DESCRIPTION
when the arrow scroller was hidden it was still blocking components under it from being clicked on