### PR TITLE
fix: table error

### DIFF
--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -783,7 +783,7 @@ function TableRef(
                     key={key}
                     onClick={(e) => onRowClick?.(e, row)}
                     $raised={raised}
-                    $highlighted={row.id === highlightedRowId}
+                    $highlighted={row?.id === highlightedRowId}
                     $selectable={row?.getCanSelect() ?? false}
                     $selected={row?.getIsSelected() ?? false}
                     $clickable={!!onRowClick}


### PR DESCRIPTION
was trying to pull an id from a null value any time a loader row was rendered (this is what was happening in the users table because the default page size there is 20)