### PR TITLE
fix: table highlighting and modal fill level

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -79,14 +79,13 @@ const sizeToWidth = {
 const ModalSC = styled(Card)<{
   $width: number
   $maxWidth: number
-}>(({ theme, $width, $maxWidth }) => ({
+}>(({ $width, $maxWidth }) => ({
   position: 'relative',
   display: 'flex',
   flexDirection: 'column',
   height: '100%',
   width: $width,
   maxWidth: $maxWidth,
-  backgroundColor: theme.colors['fill-one'],
 }))
 
 const ModalContentSC = styled.div<{
@@ -186,6 +185,7 @@ function ModalRef(
       {...props}
     >
       <ModalSC
+        fillLevel={1}
         forwardedAs={asForm ? 'form' : undefined}
         $width={sizeToWidth[size]}
         $maxWidth={maxWidth}

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -172,7 +172,8 @@ const Tr = styled.tr<{
     ...(clickable && {
       cursor: 'pointer',
 
-      '&:hover': {
+      // highlight when hovered, but don't highlight if a child button is hovered
+      '&:not(:has(button:hover)):hover': {
         backgroundColor: selectable
           ? selected
             ? theme.colors['fill-zero-hover']


### PR DESCRIPTION
makes modals have a consistent fill level, and also makes table row hover state go away when inner buttons are hovered