### PR TITLE
fix: treenav issue

### DIFF
--- a/src/components/ComboBox.tsx
+++ b/src/components/ComboBox.tsx
@@ -110,7 +110,6 @@ function OpenButton({
   buttonProps,
   ...props
 }: HTMLAttributes<HTMLDivElement> & {
-  isOpen?: boolean
   buttonRef: RefObject<any>
   buttonProps: AriaButtonProps
 }) {
@@ -157,7 +156,6 @@ function ComboBoxInput({
   buttonProps,
   showArrow = true,
   hasChips = false,
-  isOpen,
   onInputClick,
   loading,
   ...props
@@ -186,7 +184,6 @@ function ComboBoxInput({
       dropdownButton={
         showArrow ? (
           <OpenButton
-            isOpen={isOpen}
             buttonRef={buttonRef}
             buttonProps={buttonProps}
           />

--- a/src/components/TreeNavigation.tsx
+++ b/src/components/TreeNavigation.tsx
@@ -177,7 +177,7 @@ function NavLink({
           paddingRight: 0,
         }}
         textDecoration="none"
-        {...(href ? { as: Link } : {})}
+        {...(href ? { as: Link, href } : {})}
         {...props}
       >
         <Div


### PR DESCRIPTION
quick fix for links not being passed correctly to treenav components

also removed an unused prop causing a console warning