### PR TITLE
fix: revert incorrect transient props

### DIFF
--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -78,10 +78,10 @@ export type SelectProps = Exclude<SelectButtonProps, 'children'> & {
 type TriggerProps = {
   buttonRef: RefObject<HTMLElement>
   buttonElt: any
-  $isOpen: boolean
+  isOpen: boolean
 } & HTMLAttributes<HTMLElement>
 
-function Trigger({ buttonElt, $isOpen, ...props }: TriggerProps) {
+function Trigger({ buttonElt, isOpen, ...props }: TriggerProps) {
   const ref = props.buttonRef
   const { buttonProps } = useButton(props, ref)
   const theme = useTheme()
@@ -90,10 +90,10 @@ function Trigger({ buttonElt, $isOpen, ...props }: TriggerProps) {
     ref,
     ...buttonProps,
     ...(buttonElt?.props?.type ? { type: buttonElt.props.type } : {}),
-    $isOpen,
+    isOpen,
     style: {
       appearance: 'unset',
-      ...($isOpen ? { zIndex: theme.zIndexes.tooltip + 1 } : {}),
+      ...(isOpen ? { zIndex: theme.zIndexes.tooltip + 1 } : {}),
     },
     tabIndex: 0,
   })
@@ -374,7 +374,7 @@ function Select({
       <Trigger
         buttonRef={triggerRef as unknown as RefObject<HTMLElement>}
         buttonElt={triggerButton}
-        $isOpen={state.isOpen}
+        isOpen={state.isOpen}
         {...triggerProps}
       />
       <PopoverListBox

--- a/src/components/TabList.tsx
+++ b/src/components/TabList.tsx
@@ -183,7 +183,7 @@ const TabClone = styled(
       ref: tabRef,
       ...props,
     })
-)<{ $vertical: boolean }>(({ theme, $vertical: vertical }) => ({
+)<{ vertical: boolean }>(({ theme, vertical }) => ({
   position: 'relative',
   '&:focus, &:focus-visible': {
     outline: 'none',
@@ -244,7 +244,7 @@ function TabRenderer({ item, state, stateProps, stateRef }: TabRendererProps) {
       tabRef={ref}
       {...props}
       active={state.selectedKey === item.key}
-      $vertical={stateProps.orientation === 'vertical'}
+      vertical={stateProps.orientation === 'vertical'}
       {...item.props}
     >
       {item.rendered}

--- a/src/components/TagMultiSelect.tsx
+++ b/src/components/TagMultiSelect.tsx
@@ -34,12 +34,10 @@ type TagMultiSelectProps = {
   selectProps?: Omit<SelectPropsSingle, 'children'>
 }
 
-const MultiSelectMatchButtonContainer = styled.div`
-  > div {
-    border-top-right-radius: 0;
-    border-bottom-right-radius: 0;
-    border-right: none;
-  }
+const MultiSelectMatchButtonContainer = styled(SelectButton)`
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+  border-right: none;
 `
 
 const TagMultiSelect = styled(TagMultiSelectUnstyled)(({ theme }) => ({
@@ -94,9 +92,7 @@ function TagMultiSelectUnstyled({
           defaultOpen={false}
           triggerButton={
             <MultiSelectMatchButtonContainer>
-              <SelectButton>
-                {matchOptions.find((el) => el.value === searchLogic).label}
-              </SelectButton>
+              {matchOptions.find((el) => el.value === searchLogic).label}
             </MultiSelectMatchButtonContainer>
           }
           {...selectProps}


### PR DESCRIPTION
reverts a couple changes from https://github.com/pluralsh/design-system/pull/650/ in cases where styled component props actually do need to propagate to children

also unrelated fix for TagMultiSelect arrows not flipping up and down when the select opens