### PR TITLE
fix: arrow scroll z index

### DIFF
--- a/src/components/ArrowScroll.tsx
+++ b/src/components/ArrowScroll.tsx
@@ -25,7 +25,7 @@ const ArrowWrapperSC = styled.div<{
   $direction?: 'left' | 'right'
 }>(({ theme, $direction }) => ({
   color: theme.colors['icon-light'],
-  zIndex: theme.zIndexes.modal,
+  zIndex: theme.zIndexes.modal - 1,
   position: 'absolute',
   top: 0,
   bottom: 0,


### PR DESCRIPTION
fixes this bug:

<img width="772" alt="Screenshot 2024-11-15 at 9 12 07 AM" src="https://github.com/user-attachments/assets/a14e0d77-01cf-4343-8591-2f15e2f6a61b">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted the stacking order of arrow components to improve visibility of overlapping elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->