### PR TITLE
feat: improve table expander

### DIFF
--- a/src/components/contexts/FillLevelContext.tsx
+++ b/src/components/contexts/FillLevelContext.tsx
@@ -1,4 +1,5 @@
 import { createContext, useContext } from 'react'
+import { TableFillLevel } from '../table/Table'
 
 const MIN_FILL = 0
 const MAX_FILL = 3
@@ -11,6 +12,10 @@ export const useFillLevel = () => useContext(FillLevelContext)
 
 export function toFillLevel(x: number | FillLevel): FillLevel {
   return Math.max(Math.min(Math.floor(x), MAX_FILL), MIN_FILL) as FillLevel
+}
+
+export function toTableFillLevel(x: number | FillLevel): TableFillLevel {
+  return Math.max(Math.min(Math.floor(x), 2), 0) as TableFillLevel
 }
 
 const isInteger = (x: unknown): x is number => Number.isInteger(x)

--- a/src/components/contexts/FillLevelContext.tsx
+++ b/src/components/contexts/FillLevelContext.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext } from 'react'
-import { TableFillLevel } from '../table/Table'
+import { TableFillLevel } from '../table/tableUtils'
 
 const MIN_FILL = 0
 const MAX_FILL = 3

--- a/src/components/table/FillerRows.tsx
+++ b/src/components/table/FillerRows.tsx
@@ -1,7 +1,7 @@
 import type { Row } from '@tanstack/react-table'
 import type { VirtualItem } from '@tanstack/react-virtual'
 
-import { type TableFillLevel } from './Table'
+import { type TableFillLevel } from './tableUtils'
 import { Td } from './Td'
 import { Tr } from './Tr'
 

--- a/src/components/table/Table.tsx
+++ b/src/components/table/Table.tsx
@@ -1,10 +1,4 @@
-import { rankItem } from '@tanstack/match-sorter-utils'
-import type {
-  ColumnDef,
-  FilterFn,
-  Row,
-  TableOptions,
-} from '@tanstack/react-table'
+import type { Row } from '@tanstack/react-table'
 import {
   flexRender,
   getCoreRowModel,
@@ -13,15 +7,10 @@ import {
   getSortedRowModel,
   useReactTable,
 } from '@tanstack/react-table'
-import type { VirtualItem } from '@tanstack/react-virtual'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { isEmpty, isNil } from 'lodash-es'
 import {
-  type CSSProperties,
   Fragment,
-  type MouseEvent,
-  type RefObject,
-  type UIEventHandler,
   useCallback,
   useEffect,
   useMemo,
@@ -30,14 +19,9 @@ import {
 } from 'react'
 import styled, { useTheme } from 'styled-components'
 
-import {
-  type FillLevel,
-  InfoOutlineIcon,
-  Tooltip,
-  WrapWithIf,
-} from '../../index'
+import { InfoOutlineIcon, Tooltip, WrapWithIf } from '../../index'
 import Button from '../Button'
-import EmptyState, { type EmptyStateProps } from '../EmptyState'
+import EmptyState from '../EmptyState'
 import CaretUpIcon from '../icons/CaretUpIcon'
 import { Spinner } from '../Spinner'
 
@@ -48,99 +32,23 @@ import {
   tableFillLevelToHighlightedCellBg,
 } from './colors'
 import { FillerRows } from './FillerRows'
-import { useIsScrolling, useOnVirtualSliceChange } from './hooks'
+import { useOnVirtualSliceChange } from './hooks'
 import { Skeleton } from './Skeleton'
 import { SortIndicator } from './SortIndicator'
 import { T } from './T'
+import {
+  defaultGlobalFilterFn,
+  getGridTemplateCols,
+  isRow,
+  isValidId,
+  measureElementHeight,
+  TableProps,
+} from './tableUtils'
 import { Tbody } from './Tbody'
 import { Td, TdBasic, TdExpand, TdLoading } from './Td'
 import { Th } from './Th'
 import { Thead } from './Thead'
 import { Tr } from './Tr'
-
-export type TableProps = Omit<CSSProperties, keyof TableBaseProps> &
-  TableBaseProps
-
-type TableBaseProps = {
-  ref?: RefObject<HTMLDivElement>
-  data: any[]
-  columns: any[]
-  loading?: boolean
-  loadingSkeletonRows?: number
-  hideHeader?: boolean
-  padCells?: boolean
-  expandedRowType?: 'default' | 'custom'
-  fullHeightWrap?: boolean
-  fillLevel?: TableFillLevel
-  rowBg?: 'base' | 'raised' | 'stripes'
-  highlightedRowId?: string
-  getRowCanExpand?: any
-  renderExpanded?: any
-  loose?: boolean
-  stickyColumn?: boolean
-  scrollTopMargin?: number
-  flush?: boolean
-  virtualizeRows?: boolean
-  lockColumnsOnScroll?: boolean
-  reactVirtualOptions?: Partial<
-    Omit<Parameters<typeof useVirtualizer>[0], 'count' | 'getScrollElement'>
-  >
-  reactTableOptions?: Partial<Omit<TableOptions<any>, 'data' | 'columns'>>
-  onRowClick?: (e: MouseEvent<HTMLTableRowElement>, row: Row<any>) => void
-  emptyStateProps?: EmptyStateProps
-  hasNextPage?: boolean
-  fetchNextPage?: () => void
-  isFetchingNextPage?: boolean
-  onVirtualSliceChange?: (slice: VirtualSlice) => void
-  onScrollCapture?: UIEventHandler<HTMLDivElement>
-}
-
-export type TableFillLevel = Exclude<FillLevel, 3>
-
-export type VirtualSlice = {
-  start: VirtualItem | undefined
-  end: VirtualItem | undefined
-}
-
-function getGridTemplateCols(columnDefs: ColumnDef<unknown>[] = []): string {
-  return columnDefs
-    .reduce(
-      (val: string[], columnDef): string[] => [
-        ...val,
-        columnDef.meta?.gridTemplate
-          ? columnDef.meta?.gridTemplate
-          : columnDef.meta?.truncate
-          ? 'minmax(100px, 1fr)'
-          : 'auto',
-      ],
-      [] as string[]
-    )
-    .join(' ')
-}
-
-function isRow<T>(row: Row<T> | VirtualItem): row is Row<T> {
-  return typeof (row as Row<T>).getVisibleCells === 'function'
-}
-
-function isValidId(id: unknown) {
-  return typeof id === 'number' || (typeof id === 'string' && id.length > 0)
-}
-
-const defaultGlobalFilterFn: FilterFn<any> = (
-  row,
-  columnId,
-  value,
-  addMeta
-) => {
-  // Rank the item
-  const itemRank = rankItem(row.getValue(columnId), value)
-
-  // Store the ranking info
-  addMeta(itemRank)
-
-  // Return if the item should be filtered in/out
-  return itemRank.passed
-}
 
 function Table({
   ref: forwardedRef,
@@ -179,6 +87,8 @@ function Table({
   const tableContainerRef = useRef<HTMLDivElement>(undefined)
   const [hover, setHover] = useState(false)
   const [scrollTop, setScrollTop] = useState(0)
+  const [expanded, setExpanded] = useState({})
+
   const table = useReactTable({
     data,
     columns,
@@ -202,8 +112,14 @@ function Table({
       sortingFn: 'alphanumeric',
     },
     enableRowSelection: false,
+    onExpandedChange: setExpanded,
     ...reactTableOptions,
+    state: {
+      expanded,
+      ...reactTableOptions?.state,
+    },
   })
+
   const [fixedGridTemplateColumns, setFixedGridTemplateColumns] = useState<
     string | null
   >(null)
@@ -214,23 +130,18 @@ function Table({
   >((i) => tableRows[i]?.id || i, [tableRows])
   const rowVirtualizer = useVirtualizer({
     count: hasNextPage ? tableRows.length + 1 : tableRows.length,
-    overscan: 6,
+    overscan: 0,
     getItemKey,
     getScrollElement: () => tableContainerRef.current,
     estimateSize: () => 52,
     measureElement: (el) => {
-      // Since <td>s are rendered with `display: contents`, we need to calculate
-      // row height from contents using Range
-      if (el?.getBoundingClientRect().height <= 0 && el?.hasChildNodes()) {
-        const range = document.createRange()
+      let totalHeight = measureElementHeight(el)
+      // add height of expanded row if present
+      const sibling = el.nextElementSibling
+      if (sibling?.getAttribute('data-expander-row'))
+        totalHeight += measureElementHeight(sibling)
 
-        range.setStart(el, 0)
-        range.setEnd(el, el.childNodes.length)
-
-        return range.getBoundingClientRect().height
-      }
-
-      return el.getBoundingClientRect().height
+      return totalHeight
     },
     ...reactVirtualOptions,
   })
@@ -239,32 +150,21 @@ function Table({
 
   useOnVirtualSliceChange({ virtualRows, virtualizeRows, onVirtualSliceChange })
 
-  lockColumnsOnScroll = lockColumnsOnScroll ?? virtualizeRows
-  useIsScrolling(tableContainerRef, {
-    onIsScrollingChange: useCallback(
-      (isScrolling) => {
-        if (lockColumnsOnScroll) {
-          const thCells = tableContainerRef.current?.querySelectorAll('th')
-
-          const columns = Array.from(thCells)
-            .map((th) => {
-              const { width } = th.getBoundingClientRect()
-
-              return `${width}px`
-            })
-            .join(' ')
-
-          setFixedGridTemplateColumns(isScrolling ? columns : null)
-        }
-      },
-      [lockColumnsOnScroll]
-    ),
-  })
+  // lock column widths when scrolling
   useEffect(() => {
-    if (!lockColumnsOnScroll) {
+    if ((lockColumnsOnScroll ?? virtualizeRows) && rowVirtualizer.isScrolling) {
+      const thCells = tableContainerRef.current?.querySelectorAll('th')
+      const columns = Array.from(thCells)
+        .map((th) => {
+          const { width } = th.getBoundingClientRect()
+          return `${width}px`
+        })
+        .join(' ')
+      setFixedGridTemplateColumns(columns)
+    } else {
       setFixedGridTemplateColumns(null)
     }
-  }, [lockColumnsOnScroll])
+  }, [lockColumnsOnScroll, rowVirtualizer.isScrolling, virtualizeRows])
 
   const { paddingTop, paddingBottom } = useMemo(
     () => ({
@@ -436,31 +336,34 @@ function Table({
                   {rows.map((maybeRow) => {
                     const i = maybeRow.index
                     const isLoaderRow = i > tableRows.length - 1
-                    const row: Row<unknown> | null = isRow(maybeRow)
+                    const tableRow: Row<unknown> | null = isRow(maybeRow)
                       ? maybeRow
                       : isLoaderRow
                       ? null
                       : tableRows[maybeRow.index]
-                    const key = row?.id ?? maybeRow.index
+                    const virtualRow = !isRow(maybeRow) ? maybeRow : null
+                    const key =
+                      virtualRow?.key ?? tableRow?.id ?? maybeRow.index
 
                     return (
                       <Fragment key={key}>
                         <Tr
-                          key={key}
-                          onClick={(e) => onRowClick?.(e, row)}
+                          key={`${key}-${tableRow?.getIsExpanded()}`} // forces row to be rerendered (and remeasured) when expanded state changes
+                          data-index={virtualRow?.index} // required for virtual scrolling to work
+                          ref={
+                            virtualizeRows
+                              ? rowVirtualizer.measureElement
+                              : undefined
+                          }
+                          onClick={(e) => onRowClick?.(e, tableRow)}
                           $fillLevel={fillLevel}
                           $raised={isRaised(i)}
-                          $highlighted={row?.id === highlightedRowId}
-                          $selectable={row?.getCanSelect() ?? false}
-                          $selected={row?.getIsSelected() ?? false}
+                          $highlighted={tableRow?.id === highlightedRowId}
+                          $selectable={tableRow?.getCanSelect() ?? false}
+                          $selected={tableRow?.getIsSelected() ?? false}
                           $clickable={!!onRowClick}
-                          // data-index is required for virtual scrolling to work
-                          data-index={row?.index}
-                          {...(virtualizeRows
-                            ? { ref: rowVirtualizer.measureElement }
-                            : {})}
                         >
-                          {isNil(row) && isLoaderRow ? (
+                          {isNil(tableRow) && isLoaderRow ? (
                             <TdLoading
                               key={i}
                               $fillLevel={fillLevel}
@@ -476,7 +379,7 @@ function Table({
                               <Spinner color={theme.colors['text-xlight']} />
                             </TdLoading>
                           ) : (
-                            row?.getVisibleCells().map((cell) => (
+                            tableRow?.getVisibleCells().map((cell) => (
                               <Td
                                 key={cell.id}
                                 $fillLevel={fillLevel}
@@ -500,8 +403,9 @@ function Table({
                             ))
                           )}
                         </Tr>
-                        {row?.getIsExpanded() && (
+                        {tableRow?.getIsExpanded() && (
                           <Tr
+                            data-expander-row
                             $fillLevel={fillLevel}
                             $raised={isRaised(i)}
                             $type="expander"
@@ -510,14 +414,18 @@ function Table({
                               <>
                                 <TdExpand css={{ borderTop: expanderBorder }} />
                                 <TdExpand
-                                  colSpan={row.getVisibleCells().length - 1}
+                                  colSpan={
+                                    tableRow.getVisibleCells().length - 1
+                                  }
                                   css={{ borderTop: expanderBorder }}
                                 >
-                                  {renderExpanded({ row })}
+                                  {renderExpanded({ row: tableRow })}
                                 </TdExpand>
                               </>
                             ) : (
-                              <TdBasic>{renderExpanded({ row })}</TdBasic>
+                              <TdBasic>
+                                {renderExpanded({ row: tableRow })}
+                              </TdBasic>
                             )}
                           </Tr>
                         )}

--- a/src/components/table/Table.tsx
+++ b/src/components/table/Table.tsx
@@ -41,14 +41,19 @@ import EmptyState, { type EmptyStateProps } from '../EmptyState'
 import CaretUpIcon from '../icons/CaretUpIcon'
 import { Spinner } from '../Spinner'
 
-import { tableFillLevelToBg, tableFillLevelToBorderColor } from './colors'
+import { toTableFillLevel } from '../contexts/FillLevelContext'
+import {
+  tableFillLevelToBg,
+  tableFillLevelToBorderColor,
+  tableFillLevelToHighlightedCellBg,
+} from './colors'
 import { FillerRows } from './FillerRows'
 import { useIsScrolling, useOnVirtualSliceChange } from './hooks'
 import { Skeleton } from './Skeleton'
 import { SortIndicator } from './SortIndicator'
 import { T } from './T'
 import { Tbody } from './Tbody'
-import { Td, TdExpand, TdLoading } from './Td'
+import { Td, TdBasic, TdExpand, TdLoading } from './Td'
 import { Th } from './Th'
 import { Thead } from './Thead'
 import { Tr } from './Tr'
@@ -64,6 +69,7 @@ type TableBaseProps = {
   loadingSkeletonRows?: number
   hideHeader?: boolean
   padCells?: boolean
+  expandedRowType?: 'default' | 'custom'
   fullHeightWrap?: boolean
   fillLevel?: TableFillLevel
   rowBg?: 'base' | 'raised' | 'stripes'
@@ -147,6 +153,7 @@ function Table({
   renderExpanded,
   loose = false,
   padCells = true,
+  expandedRowType = 'default',
   fullHeightWrap = false, // TODO: default this to true after regression testing
   fillLevel = 0,
   rowBg = 'stripes',
@@ -291,6 +298,11 @@ function Table({
     (i: number) => rowBg === 'raised' || (rowBg === 'stripes' && i % 2 === 1),
     [rowBg]
   )
+
+  const expanderBorder =
+    theme.borders[
+      tableFillLevelToHighlightedCellBg[toTableFillLevel(fillLevel)]
+    ]
 
   useEffect(() => {
     const lastItem = virtualRows[virtualRows.length - 1]
@@ -491,14 +503,22 @@ function Table({
                         {row?.getIsExpanded() && (
                           <Tr
                             $fillLevel={fillLevel}
-                            $raised={i % 2 === 1}
+                            $raised={isRaised(i)}
+                            $type="expander"
                           >
-                            <TdExpand />
-                            <TdExpand
-                              colSpan={row.getVisibleCells().length - 1}
-                            >
-                              {renderExpanded({ row })}
-                            </TdExpand>
+                            {expandedRowType === 'default' ? (
+                              <>
+                                <TdExpand css={{ borderTop: expanderBorder }} />
+                                <TdExpand
+                                  colSpan={row.getVisibleCells().length - 1}
+                                  css={{ borderTop: expanderBorder }}
+                                >
+                                  {renderExpanded({ row })}
+                                </TdExpand>
+                              </>
+                            ) : (
+                              <TdBasic>{renderExpanded({ row })}</TdBasic>
+                            )}
                           </Tr>
                         )}
                       </Fragment>

--- a/src/components/table/Td.tsx
+++ b/src/components/table/Td.tsx
@@ -4,7 +4,7 @@ import {
   tableFillLevelToBorder,
   tableFillLevelToHighlightedCellBg,
 } from './colors'
-import { type TableFillLevel } from './Table'
+import { type TableFillLevel } from './tableUtils'
 
 export const Td = styled.td<{
   $fillLevel: TableFillLevel

--- a/src/components/table/Td.tsx
+++ b/src/components/table/Td.tsx
@@ -88,3 +88,7 @@ export const TdLoading = styled(Td)(({ theme }) => ({
   color: theme.colors['text-xlight'],
   minHeight: theme.spacing.large * 2 + theme.spacing.xlarge,
 }))
+
+export const TdBasic = styled.td({
+  gridColumn: '1 / -1',
+})

--- a/src/components/table/Th.tsx
+++ b/src/components/table/Th.tsx
@@ -2,7 +2,7 @@ import type { CSSProperties } from 'react'
 import styled from 'styled-components'
 
 import { tableFillLevelToBorder, tableHeaderColor } from './colors'
-import { type TableFillLevel } from './Table'
+import { type TableFillLevel } from './tableUtils'
 
 export const Th = styled.th<{
   $fillLevel: TableFillLevel

--- a/src/components/table/Tr.tsx
+++ b/src/components/table/Tr.tsx
@@ -10,6 +10,7 @@ export const Tr = styled.tr<{
   $selectable?: boolean
   $clickable?: boolean
   $raised?: boolean
+  $type?: 'regular' | 'expander'
 }>(
   ({
     theme,
@@ -19,11 +20,14 @@ export const Tr = styled.tr<{
     $selected: selected = false,
     $highlighted: highlighted = false,
     $fillLevel: fillLevel,
+    $type: type = 'regular',
   }) => ({
     display: 'contents',
     backgroundColor:
       theme.colors[
-        tableCellColor(fillLevel, highlighted, raised, selectable, selected)
+        type === 'expander'
+          ? tableCellHoverColor(fillLevel, selectable, selected)
+          : tableCellColor(fillLevel, highlighted, raised, selectable, selected)
       ],
 
     ...(clickable && {

--- a/src/components/table/Tr.tsx
+++ b/src/components/table/Tr.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components'
 
 import { tableCellColor, tableCellHoverColor } from './colors'
-import { type TableFillLevel } from './Table'
+import { type TableFillLevel } from './tableUtils'
 
 export const Tr = styled.tr<{
   $fillLevel: TableFillLevel

--- a/src/components/table/colors.ts
+++ b/src/components/table/colors.ts
@@ -1,4 +1,4 @@
-import { type TableFillLevel } from './Table'
+import { TableFillLevel } from './tableUtils'
 
 export const tableFillLevelToBorder = {
   0: 'fill-two',

--- a/src/components/table/hooks.ts
+++ b/src/components/table/hooks.ts
@@ -3,7 +3,7 @@ import { type RefObject, useEffect, useRef, useState } from 'react'
 
 import usePrevious from '../../hooks/usePrevious'
 
-import { type VirtualSlice } from './Table'
+import { type VirtualSlice } from './tableUtils'
 
 export function useIsScrolling(
   ref: RefObject<HTMLElement>,

--- a/src/components/table/tableUtils.ts
+++ b/src/components/table/tableUtils.ts
@@ -1,0 +1,119 @@
+import { rankItem } from '@tanstack/match-sorter-utils'
+import type {
+  ColumnDef,
+  FilterFn,
+  Row,
+  TableOptions,
+} from '@tanstack/react-table'
+import type { VirtualItem } from '@tanstack/react-virtual'
+import { useVirtualizer } from '@tanstack/react-virtual'
+import {
+  type CSSProperties,
+  type MouseEvent,
+  type RefObject,
+  type UIEventHandler,
+} from 'react'
+
+import { type FillLevel } from '../../index'
+import { type EmptyStateProps } from '../EmptyState'
+
+export type TableProps = Omit<CSSProperties, keyof TableBaseProps> &
+  TableBaseProps
+
+export type TableBaseProps = {
+  ref?: RefObject<HTMLDivElement>
+  data: any[]
+  columns: any[]
+  loading?: boolean
+  loadingSkeletonRows?: number
+  hideHeader?: boolean
+  padCells?: boolean
+  expandedRowType?: 'default' | 'custom'
+  fullHeightWrap?: boolean
+  fillLevel?: TableFillLevel
+  rowBg?: 'base' | 'raised' | 'stripes'
+  highlightedRowId?: string
+  getRowCanExpand?: any
+  renderExpanded?: any
+  loose?: boolean
+  stickyColumn?: boolean
+  scrollTopMargin?: number
+  flush?: boolean
+  virtualizeRows?: boolean
+  lockColumnsOnScroll?: boolean
+  reactVirtualOptions?: Partial<
+    Omit<Parameters<typeof useVirtualizer>[0], 'count' | 'getScrollElement'>
+  >
+  reactTableOptions?: Partial<Omit<TableOptions<any>, 'data' | 'columns'>>
+  onRowClick?: (e: MouseEvent<HTMLTableRowElement>, row: Row<any>) => void
+  emptyStateProps?: EmptyStateProps
+  hasNextPage?: boolean
+  fetchNextPage?: () => void
+  isFetchingNextPage?: boolean
+  onVirtualSliceChange?: (slice: VirtualSlice) => void
+  onScrollCapture?: UIEventHandler<HTMLDivElement>
+}
+
+export type TableFillLevel = Exclude<FillLevel, 3>
+
+export type VirtualSlice = {
+  start: VirtualItem | undefined
+  end: VirtualItem | undefined
+}
+
+export function getGridTemplateCols(
+  columnDefs: ColumnDef<unknown>[] = []
+): string {
+  return columnDefs
+    .reduce(
+      (val: string[], columnDef): string[] => [
+        ...val,
+        columnDef.meta?.gridTemplate
+          ? columnDef.meta?.gridTemplate
+          : columnDef.meta?.truncate
+          ? 'minmax(100px, 1fr)'
+          : 'auto',
+      ],
+      [] as string[]
+    )
+    .join(' ')
+}
+
+export function isRow<T>(row: Row<T> | VirtualItem): row is Row<T> {
+  return typeof (row as Row<T>).getVisibleCells === 'function'
+}
+
+export function isValidId(id: unknown) {
+  return typeof id === 'number' || (typeof id === 'string' && id.length > 0)
+}
+
+export const defaultGlobalFilterFn: FilterFn<any> = (
+  row,
+  columnId,
+  value,
+  addMeta
+) => {
+  // Rank the item
+  const itemRank = rankItem(row.getValue(columnId), value)
+
+  // Store the ranking info
+  addMeta(itemRank)
+
+  // Return if the item should be filtered in/out
+  return itemRank.passed
+}
+
+export function measureElementHeight(element: Element): number {
+  // Since <td>s are rendered with `display: contents`, we need to calculate
+  // row height from contents using Range
+  if (
+    element?.getBoundingClientRect().height <= 0 &&
+    element?.hasChildNodes()
+  ) {
+    const range = document.createRange()
+    range.setStart(element, 0)
+    range.setEnd(element, element.childNodes.length)
+    return range.getBoundingClientRect().height
+  }
+  return element.getBoundingClientRect().height
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,8 @@ export { default as Tab } from './components/Tab'
 export type { TabListStateProps, TabBaseProps } from './components/TabList'
 export { TabList } from './components/TabList'
 export { default as TabPanel } from './components/TabPanel'
-export { default as Table, type TableProps } from './components/table/Table'
+export { default as Table } from './components/table/Table'
+export type { TableProps } from './components/table/tableUtils'
 export { default as TipCarousel } from './components/TipCarousel'
 export {
   type ValidationResponse,


### PR DESCRIPTION
gives a more distinguished background color to expander rows and adds a top border to them
plus adds an escape hatch in case we need more flexibility

also fixes some bugs related to virtualization which were causing virtualized tables to be pretty glitchy with expander rows, even more so if the columns were sorted
(main fix was ensuring the virtualizer includes the expanded content when measuring an open row's height, as well as ensuring data-index tracks the virtual row index as opposed to the original table index)