### PR TITLE
fix: switch within table bug

### DIFF
--- a/src/components/Switch.tsx
+++ b/src/components/Switch.tsx
@@ -30,6 +30,7 @@ export type SwitchProps = UseSwitchProps & { className?: string }
 
 const SwitchSC = styled.label<SwitchStyleProps>(
   ({ $checked, $disabled, $readOnly, theme }) => ({
+    position: 'relative',
     display: 'flex',
     columnGap: theme.spacing.xsmall,
     alignItems: 'center',


### PR DESCRIPTION
the hidden, absolute positioned input within toggle switches was causing weird behavior when toggling within a virtualized table row outside that wasn't in the initial table view (so basically any row you had to scroll to). it would jump to where the row is in the dom rather than where it's actually being rendered by the virtualize, causing random bugs like making the table disappear

adding position:relative to the wrapper keeps everything contained and fixes the issue