### PR TITLE
feat: add "Remeasure Fonts" action to CodeEditor and update Select disabled state styling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
           projectId: pluralsh-design
   trivy-scan:
     name: Trivy fs scan
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     permissions:
       contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results

--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -63,10 +63,7 @@ export default function CodeEditor({
       id: 'remeasure-fonts',
       label: 'Remeasure Fonts',
       keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyB],
-      run: () => {
-        console.log(monaco?.editor?.remeasureFonts)
-        monaco?.editor?.remeasureFonts()
-      },
+      run: () => monaco?.editor?.remeasureFonts(),
     })
   }
 

--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -58,6 +58,18 @@ export default function CodeEditor({
   const [copied, setCopied] = useState<boolean>(false)
   const changed = current !== value
 
+  const onEditorMount = (editor: any) => {
+    editor.addAction({
+      id: 'remeasure-fonts',
+      label: 'Remeasure Fonts',
+      keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyB],
+      run: () => {
+        console.log(monaco?.editor?.remeasureFonts)
+        monaco?.editor?.remeasureFonts()
+      },
+    })
+  }
+
   useEffect(() => {
     if (copied) {
       const timeout = setTimeout(() => setCopied(false), 1000)
@@ -106,6 +118,7 @@ export default function CodeEditor({
           }}
           options={merge(defaultOptions, options)}
           theme={theme.mode === 'light' ? 'plural-light' : 'plural-dark'}
+          onMount={onEditorMount}
         />
       </Div>
       {save && (

--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -51,6 +51,7 @@ type SelectButtonProps = {
   isOpen?: boolean
   size?: Size
   transparent?: boolean
+  isDisabled?: boolean
 }
 
 export type SelectProps = Exclude<SelectButtonProps, 'children'> & {
@@ -128,6 +129,7 @@ const SelectButtonInner = styled.div<{
   $size: Size
   $parentFillLevel: FillLevel
   $transparent?: boolean
+  $isDisabled?: boolean
 }>(
   ({
     theme,
@@ -135,6 +137,7 @@ const SelectButtonInner = styled.div<{
     $size: size,
     $parentFillLevel: parentFillLevel,
     $transparent: transparent = false,
+    $isDisabled: isDisabled = false,
   }) => ({
     ...theme.partials.reset.button,
     ...theme.partials.text.body2,
@@ -185,6 +188,16 @@ const SelectButtonInner = styled.div<{
       color: theme.colors.text,
       cursor: 'pointer',
     },
+    ...(isDisabled && {
+      borderColor: theme.colors['border-disabled'],
+      color: theme.colors['text-input-disabled'],
+      cursor: 'not-allowed',
+
+      '&:hover': {
+        borderColor: theme.colors['border-disabled'],
+        color: theme.colors['text-input-disabled'],
+      },
+    }),
   })
 )
 
@@ -198,6 +211,7 @@ function SelectButton({
   isOpen,
   size = 'medium',
   transparent = false,
+  isDisabled,
   ...props
 }: SelectButtonProps & ComponentProps<'div'>) {
   const parentFillLevel = useFillLevel()
@@ -209,6 +223,7 @@ function SelectButton({
       $size={size}
       $parentFillLevel={parentFillLevel}
       $transparent={transparent}
+      $isDisabled={isDisabled}
       {...props}
     >
       {titleContent && (
@@ -332,6 +347,7 @@ function Select({
       showArrow={!props.isDisabled}
       size={size}
       transparent={transparent}
+      isDisabled={props.isDisabled}
     >
       {(props.selectionMode === 'multiple' &&
         state.selectedItems.length > 0 &&

--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -344,7 +344,6 @@ function Select({
       leftContent={leftContent}
       rightContent={rightContent}
       isOpen={state.isOpen}
-      showArrow={!props.isDisabled}
       size={size}
       transparent={transparent}
       isDisabled={props.isDisabled}

--- a/src/stories/Select.stories.tsx
+++ b/src/stories/Select.stories.tsx
@@ -21,6 +21,7 @@ import {
   SearchIcon,
   Select,
   SelectButton,
+  Spinner,
   WrapWithIf,
 } from '../index'
 
@@ -272,6 +273,20 @@ function Template({ onFillLevel }: { onFillLevel: any }) {
         <Select
           isDisabled={true}
           label="Disabled"
+        >
+          {items.slice(0, 4).map(({ key, label }) => (
+            <ListBoxItem
+              key={key}
+              label={label}
+              textValue={label}
+              leftContent={smallIcon}
+            />
+          ))}
+        </Select>
+        <Select
+          isDisabled={true}
+          label="Disabled & Loading"
+          rightContent={<Spinner />}
         >
           {items.slice(0, 4).map(({ key, label }) => (
             <ListBoxItem

--- a/src/stories/Select.stories.tsx
+++ b/src/stories/Select.stories.tsx
@@ -270,6 +270,19 @@ function Template({ onFillLevel }: { onFillLevel: any }) {
         }
       >
         <Select
+          isDisabled={true}
+          label="Disabled"
+        >
+          {items.slice(0, 4).map(({ key, label }) => (
+            <ListBoxItem
+              key={key}
+              label={label}
+              textValue={label}
+              leftContent={smallIcon}
+            />
+          ))}
+        </Select>
+        <Select
           defaultOpen={false}
           label="Pick something"
           selectedKey={selectedKey}


### PR DESCRIPTION
- add "Remeasure Fonts" action with Ctrl/Cmd+B shortcut to allow quickly fixing annoying issue when cursor position is off
![image](https://github.com/user-attachments/assets/2aba9565-2f5f-47d7-9ccb-98ad543ba558)


- add better styling to `Select` when `isDisabled` is set to true
![image](https://github.com/user-attachments/assets/e7a39514-3c75-458d-a464-4ba4f683e09c)
