### PR TITLE
fix: tooltip and gh workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -53,7 +53,7 @@ jobs:
         NODE_AUTH_TOKEN: ${{ secrets.PLURAL_BOT_NPM_TOKEN }}
   trivy-scan:
     name: Trivy fs scan
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     permissions:
       contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results

--- a/src/components/IconFrame.tsx
+++ b/src/components/IconFrame.tsx
@@ -193,6 +193,7 @@ function IconFrame<E extends ElementType = 'div'>({
   if (tooltip) {
     content = (
       <Tooltip
+        key={`${tooltip}`}
         displayOn="hover"
         arrow
         placement="top"


### PR DESCRIPTION
forces icon frame tooltips to rerender when their label changes, fixing a bug that was making tooltips persist when views jump between fullscreen and minimized

also migrates the remaining deprecated GH action runner