### PR TITLE
fix: hide overflow on custom expander rows

### DIFF
--- a/src/components/table/Td.tsx
+++ b/src/components/table/Td.tsx
@@ -97,4 +97,5 @@ export const TdLoading = styled(Td)(({ theme }) => ({
 export const TdBasic = styled.td({
   gridColumn: '1 / -1',
   padding: 0,
+  overflow: 'hidden',
 })


### PR DESCRIPTION
the only place we use this currently is the flow preview templates table, but it fixes a layout bug there