### PR TITLE
fix: markdown syntax highlighting bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "react-animate-height": "3.2.3",
     "react-aria": "3.34.3",
     "react-embed": "3.7.0",
-    "react-markdown": "9.0.1",
+    "react-markdown": "9.1.0",
     "react-merge-refs": "2.1.1",
     "react-stately": "3.32.2",
     "react-use-measure": "2.1.1",

--- a/src/components/Flex.tsx
+++ b/src/components/Flex.tsx
@@ -7,7 +7,7 @@ type FlexBaseProps = {
   /**
    * Alias for flexDirection
    */
-  direction?: 'row' | 'column'
+  direction?: 'row' | 'column' | 'row-reverse' | 'column-reverse'
   /**
    * wrap flex property
    */

--- a/yarn.lock
+++ b/yarn.lock
@@ -2792,7 +2792,7 @@ __metadata:
     react-aria: 3.34.3
     react-dom: 19.0.0
     react-embed: 3.7.0
-    react-markdown: 9.0.1
+    react-markdown: 9.1.0
     react-merge-refs: 2.1.1
     react-stately: 3.32.2
     react-transition-group: 4.4.5
@@ -16091,11 +16091,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-markdown@npm:9.0.1":
-  version: 9.0.1
-  resolution: "react-markdown@npm:9.0.1"
+"react-markdown@npm:9.1.0":
+  version: 9.1.0
+  resolution: "react-markdown@npm:9.1.0"
   dependencies:
     "@types/hast": ^3.0.0
+    "@types/mdast": ^4.0.0
     devlop: ^1.0.0
     hast-util-to-jsx-runtime: ^2.0.0
     html-url-attributes: ^3.0.0
@@ -16108,7 +16109,7 @@ __metadata:
   peerDependencies:
     "@types/react": ">=18"
     react: ">=18"
-  checksum: ca1daa650d48b84a5a9771683cdb3f3d2d418247ce0faf73ede3207c65f2a21cdebb9df37afda67f6fc8f0f0a7b9ce00eb239781954a4d6c7ad88ea4df068add
+  checksum: d78ca3b6bea23a3383d067ad8eb0aec3a22a4500663f32773be45ad38572b5f1b823184fafc85c1a35ff6290bddea42b003dc7bdfc02cf20a9e0163ecd3ea605
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
the way we were parsing the language for a codeblock seemed to be based off an older version of react-markdown, this fixes that

also refactors the component a bit to clean up and make more TS-friendly